### PR TITLE
Add relation property support to database entries

### DIFF
--- a/src/notion-client.ts
+++ b/src/notion-client.ts
@@ -237,6 +237,15 @@ async function convertPropertyValues(
       case "status":
         result[key] = { status: { name: String(value) } };
         break;
+      case "relation":
+        result[key] = {
+          relation: (Array.isArray(value) ? value : [value])
+              .filter((id) => id)
+              .map((id) => ({
+                id: String(id),
+              })),
+        };
+        break;
       default:
         break;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,6 +74,8 @@ function simplifyProperty(prop: any): unknown {
       return prop.unique_id.prefix
         ? `${prop.unique_id.prefix}-${prop.unique_id.number}`
         : String(prop.unique_id.number);
+    case "relation":
+      return prop.relation?.map((r: any) => r.id) ?? [];
     default:
       return null;
   }


### PR DESCRIPTION
## Add relation property support to database entries

This PR adds support for relation properties when creating or updating database entries. You can now pass related page IDs directly in the `properties` object.

### What changed

- **notion-client.ts** - Added handling for relation type in `convertPropertyValues()`. Takes an array of page IDs (or a single ID), filters out empty values, and formats them as Notion relation objects.
- **server.ts** - Updated `simplifyProperty()` to extract and return the list of related page IDs when reading relation fields.

### Usage

You can now include relation fields in your `add_database_entry` calls:

```json
{
  "jsonrpc": "2.0",
  "id": "1",
  "method": "tools/call",
  "params": {
    "name": "add_database_entry",
    "arguments": {
      "database_id": "00000000-0000-0000-0000-000000000000",
      "properties": {
        "Name": "Test page",
        "Project": ["00000000-0000-0000-0000-000000000000"]
      }
    }
  }
}
```

The created entry now includes the relation field with the correct linked page IDs:

```json
{
  "id": "00000000-0000-0000-0000-000000000000",
  "ID": "ID-1",
  "Project": ["00000000-0000-0000-0000-000000000000"],
  "Name": "Test page"
}
```

Relations were returning null before this change. Now they're properly stored and retrieved.