### PR TITLE
chore(deps): refresh lockfile for patched hono versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2016,9 +2016,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

Refreshes `package-lock.json` to pick up patched `hono` (4.12.12) and `@hono/node-server` (1.19.13). **Zero `package.json` diff — lockfile-only.** Six lines out, six lines in.

This unblocks CI, which had been failing on `npm audit --omit=dev` after new hono advisories landed in the GitHub advisory database.

## Why lockfile-only, not overrides or an SDK bump

A focused audit (see [`.meta/audits/hono-supply-chain-2026-04-09.md`](../blob/chore/hono-lockfile-refresh/.meta/audits/hono-supply-chain-2026-04-09.md)) ruled out the other options:

- **`overrides` in our `package.json`**: [per the npm docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json/), overrides are only honored when declared at the *consumer's* root. Ours would only affect our own CI, not downstream users. CI theater.
- **Bumping `@modelcontextprotocol/sdk`**: every 1.x SDK version (including latest `1.29.0`) pins `hono: ^4.11.4`. Bumping the SDK does not change the resolved version.
- **Lockfile refresh (this PR)**: the SDK's caret ranges already permit `hono@4.12.12` and `@hono/node-server@1.19.13`. A simple `npm update hono @hono/node-server` refreshes our committed lockfile. Zero `package.json` churn, CI unblocked, no new dependency pins to maintain.

## End-user impact

**None.** We do not publish `package-lock.json` to npm — it's not in our `files` field, and npm never publishes lockfiles regardless. A consumer installing `easy-notion-mcp` fresh today already resolves to `hono@4.12.12` / `@hono/node-server@1.19.13` via the SDK's own caret ranges. The only place carrying vulnerable versions was our committed lockfile, which affects only our own CI environment.

This is lockfile hygiene, not a security incident.

## Affected advisories

All fixed in the bumped versions:

- [GHSA-92pp-h63x-v22m](https://github.com/advisories/GHSA-92pp-h63x-v22m) — `@hono/node-server` `serveStatic` middleware bypass
- [GHSA-wmmm-f939-6g9c](https://github.com/advisories/GHSA-wmmm-f939-6g9c) — `hono` `serveStatic` repeated-slash bypass
- [GHSA-26pp-8wgv-hjvm](https://github.com/advisories/GHSA-26pp-8wgv-hjvm) — `hono` `setCookie` name validation
- [GHSA-r5rp-j6wh-rvv4](https://github.com/advisories/GHSA-r5rp-j6wh-rvv4) — `hono` `getCookie` NBSP prefix bypass
- [GHSA-xpcf-pg52-r92g](https://github.com/advisories/GHSA-xpcf-pg52-r92g) — `hono` `ipRestriction` IPv4-mapped IPv6
- [GHSA-xf4j-xp2r-rqqx](https://github.com/advisories/GHSA-xf4j-xp2r-rqqx) — `hono` `toSSG` path traversal

The audit traces the SDK's hono usage to exactly one production import — `getRequestListener` from `@hono/node-server` at `streamableHttp.js:9` — which does not touch any of the vulnerable APIs. None of these advisories were reachable from our runtime path even before the bump, but fixing our lockfile still makes CI honest and avoids encoding exception comments in the workflow file.

## Test plan

- [x] `git diff --stat package-lock.json package.json` → `package-lock.json | 12 ++++++------` (package.json untouched)
- [x] `npm audit --omit=dev` → only the pre-existing allowlisted `path-to-regexp` advisory remains
- [x] `npm test` → 80 files, 1375 tests, all pass
- [ ] CI green on this branch (confirms the audit step passes)

## Related

Unblocks #18 — CI there was failing on the same hono advisories.
