### PR TITLE
feat: add update_data_source tool and is_inline on create_database

### DIFF
--- a/src/notion-client.ts
+++ b/src/notion-client.ts
@@ -1,4 +1,5 @@
 import { Client } from "@notionhq/client";
+import type { UpdateDataSourceParameters } from "@notionhq/client/build/src/api-endpoints.js";
 import { readFile, stat } from "fs/promises";
 import { basename, extname } from "path";
 import { fileURLToPath } from "url";
@@ -35,6 +36,8 @@ function getMimeType(filePath: string): string {
 function titleRichText(content: string) {
   return [{ type: "text" as const, text: { content } }];
 }
+
+type PropertiesUpdate = UpdateDataSourceParameters["properties"];
 
 const schemaCache = new Map<string, { schema: any; expires: number }>();
 const dataSourceIdCache = new Map<string, { dsId: string; expires: number }>();
@@ -457,12 +460,45 @@ export async function createDatabase(
   parentId: string,
   title: string,
   schema: Array<{ name: string; type: string }>,
+  options?: { is_inline?: boolean },
 ) {
   return client.databases.create({
     parent: { type: "page_id", page_id: parentId },
     title: titleRichText(title),
     initial_data_source: { properties: schemaToProperties(schema) },
+    ...(options?.is_inline !== undefined ? { is_inline: options.is_inline } : {}),
   } as any);
+}
+
+export async function updateDataSource(
+  client: Client,
+  databaseId: string,
+  updates: {
+    title?: string;
+    properties?: PropertiesUpdate;
+    in_trash?: boolean;
+  },
+) {
+  if (
+    updates.title === undefined &&
+    updates.properties === undefined &&
+    updates.in_trash === undefined
+  ) {
+    throw new Error(
+      "updateDataSource: at least one of `title`, `properties`, or `in_trash` must be provided",
+    );
+  }
+
+  const dataSourceId = await getDataSourceId(client, databaseId);
+
+  const body: Record<string, unknown> = { data_source_id: dataSourceId };
+  if (updates.title !== undefined) body.title = titleRichText(updates.title);
+  if (updates.properties !== undefined) body.properties = updates.properties;
+  if (updates.in_trash !== undefined) body.in_trash = updates.in_trash;
+
+  const result = await client.dataSources.update(body as any);
+  schemaCache.delete(databaseId);
+  return result;
 }
 
 export async function queryDatabase(

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import {
   restorePage,
   searchNotion,
   uploadFile,
+  updateDataSource,
   updateDatabaseEntry,
   updatePage,
   type PageParent,
@@ -618,8 +619,43 @@ const tools = [
             required: ["name", "type"],
           },
         },
+        is_inline: { type: "boolean", description: "Create the database inline within the parent page" },
       },
       required: ["title", "parent_page_id", "schema"],
+    },
+  },
+  {
+    name: "update_data_source",
+    description: `CRITICAL — full-list semantics: when you update a select or status property's \`options\` array, you MUST send the FULL desired list. ANY existing option you omit will be permanently removed from the database, along with any relationship to rows currently using it. To ADD one option, first call get_database, then resend the full current list with your addition appended.
+
+Cannot toggle \`is_inline\` on existing databases — \`is_inline\` is a database-level field, not a data-source field. A separate \`update_database\` tool will be added in a future PR.
+
+Updates a database's schema: rename existing properties, add/update/remove select or status options, change the database title, or move it to/from trash. Use this AFTER get_database tells you the current schema. Pass the same \`database_id\` you passed to get_database — the server resolves the underlying data source internally.
+
+The \`properties\` field uses the raw Notion API shape. The server does NO merging, normalization, or validation of property payloads — whatever you send is forwarded as-is. In particular: sending \`null\` as a property value permanently DELETES that property (and any row data in it).
+
+Status property notes:
+- As of Notion's 2026-03-19 changelog, status properties are updatable via API (https://developers.notion.com/page/changelog). The legacy \`update-a-database\` and \`update-property-schema-object\` reference pages still claim status is non-updatable — ignore those; the changelog is authoritative.
+- Status property GROUPS (default: "To-do" / "In progress" / "Complete") CANNOT be reconfigured via API. Group structure must be edited in the Notion UI. New status options added via API are assigned to the default group and cannot be reassigned programmatically.
+- Known upstream issue: Notion's API may return a stale schema where options assigned to the \`in_progress\` group appear as an empty array, causing validation errors on writes (makenotion/notion-mcp-server#232). If writes to in_progress-group options fail unexpectedly, this is the likely cause.
+
+Property payload examples (raw Notion shape):
+- Rename a property:         { "Old Name": { "name": "New Name" } }
+- Replace status options:    { "Status": { "status": { "options": [{ "name": "Backlog" }, { "name": "Doing" }, { "name": "Done" }] } } }
+- Permanently delete a property and its data: { "Unused": null }
+
+This tool CANNOT update row/page data — use page update tools for that.
+
+At least one of \`title\`, \`properties\`, or \`in_trash\` must be provided; empty updates are rejected.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        database_id: { type: "string", description: "Database ID" },
+        title: { type: "string", description: "New database title" },
+        properties: { type: "object", description: "Raw Notion property update map" },
+        in_trash: { type: "boolean", description: "True to trash, false to restore" },
+      },
+      required: ["database_id"],
     },
   },
   {
@@ -1108,17 +1144,47 @@ export function createServer(
         }
         case "create_database": {
           const notion = notionClientFactory();
-          const { title, parent_page_id, schema } = args as {
+          const { title, parent_page_id, schema, is_inline } = args as {
             title: string;
             parent_page_id: string;
             schema: Array<{ name: string; type: string }>;
+            is_inline?: boolean;
           };
-          const result = await createDatabase(notion, parent_page_id, title, schema) as any;
+          const result = await createDatabase(
+            notion,
+            parent_page_id,
+            title,
+            schema,
+            is_inline === undefined ? undefined : { is_inline },
+          ) as any;
           return textResponse({
             id: result.id,
             title,
             url: result.url,
             properties: schema.map(s => s.name),
+          });
+        }
+        case "update_data_source": {
+          const notion = notionClientFactory();
+          const { database_id, title, properties, in_trash } = args as {
+            database_id: unknown;
+            title?: string;
+            properties?: Parameters<typeof updateDataSource>[2]["properties"];
+            in_trash?: boolean;
+          };
+          if (typeof database_id !== "string") {
+            throw new Error("update_data_source: `database_id` must be a string");
+          }
+          const result = await updateDataSource(notion, database_id, {
+            title,
+            properties,
+            in_trash,
+          }) as any;
+          return textResponse({
+            id: database_id,
+            title: title ?? result.title?.[0]?.plain_text ?? "",
+            url: result.url,
+            properties: Object.keys(result.properties ?? {}),
           });
         }
         case "get_database": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -626,7 +626,7 @@ const tools = [
   },
   {
     name: "update_data_source",
-    description: `CRITICAL — full-list semantics: when you update a select or status property's \`options\` array, you MUST send the FULL desired list. ANY existing option you omit will be permanently removed from the database, along with any relationship to rows currently using it. To ADD one option, first call get_database, then resend the full current list with your addition appended.
+    description: `CRITICAL — full-list semantics: when you update a select or status property's \`options\` array, you MUST send the FULL desired list. ANY existing option you omit will be permanently removed from the database, along with any relationship to rows currently using it. Rows that currently reference a removed option are SILENTLY REASSIGNED to the default group's first option (e.g. 'Not started' for status properties) — not cleared, not errored, not left dangling. NO SIGNAL IS RAISED. If you want to preserve the meaning of existing rows when removing an option, reclassify those rows to another explicit option BEFORE removing the option from the schema. To ADD one option, first call get_database, then resend the full current list with your addition appended.
 
 Cannot toggle \`is_inline\` on existing databases — \`is_inline\` is a database-level field, not a data-source field. A separate \`update_database\` tool will be added in a future PR.
 

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -133,14 +133,15 @@ describe("HTTP Transport — Static Token Mode", () => {
     expect(toolsBody.result).toBeDefined();
     expect(toolsBody.result.tools).toBeDefined();
     expect(Array.isArray(toolsBody.result.tools)).toBe(true);
-    // We should have 26 tools
-    expect(toolsBody.result.tools.length).toBe(26);
+    // We should have 27 tools
+    expect(toolsBody.result.tools.length).toBe(27);
 
     // Verify a few expected tool names
     const toolNames = toolsBody.result.tools.map((t: any) => t.name);
     expect(toolNames).toContain("create_page");
     expect(toolNames).toContain("read_page");
     expect(toolNames).toContain("search");
+    expect(toolNames).toContain("update_data_source");
   });
 
   it("returns 400 for GET /mcp without a session", async () => {

--- a/tests/update-data-source.test.ts
+++ b/tests/update-data-source.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from "vitest";
+import * as notionClient from "../src/notion-client.js";
+
+type MockClient = {
+  dataSources: {
+    update: ReturnType<typeof vi.fn>;
+    retrieve: ReturnType<typeof vi.fn>;
+  };
+  databases: {
+    retrieve: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+};
+
+function makeMockClient(overrides?: Partial<MockClient>): MockClient {
+  return {
+    dataSources: {
+      update: vi.fn().mockResolvedValue({ id: "ds-updated" }),
+      retrieve: vi.fn().mockResolvedValue({ id: "ds-1", properties: {} }),
+      ...overrides?.dataSources,
+    },
+    databases: {
+      retrieve: vi.fn().mockResolvedValue({ id: "db-1", data_sources: [{ id: "ds-1" }] }),
+      create: vi.fn().mockResolvedValue({ id: "db-created", url: "https://notion.so/db-created" }),
+      ...overrides?.databases,
+    },
+  };
+}
+
+function getUpdateDataSource() {
+  expect((notionClient as any).updateDataSource).toBeTypeOf("function");
+  return (notionClient as any).updateDataSource as (
+    client: any,
+    databaseId: string,
+    updates: {
+      title?: string;
+      properties?: Record<string, unknown>;
+      in_trash?: boolean;
+    },
+  ) => Promise<any>;
+}
+
+describe("updateDataSource", () => {
+  it("forwards a raw properties map unchanged", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-raw", data_sources: [{ id: "ds-raw" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+    const properties = {
+      Status: {
+        status: {
+          options: [{ name: "A" }, { name: "B" }],
+        },
+      },
+    };
+
+    await getUpdateDataSource()(client as any, "db-raw", { properties });
+
+    expect(client.dataSources.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data_source_id: "ds-raw",
+        properties,
+      }),
+    );
+    expect(client.dataSources.update.mock.calls[0]?.[0]?.properties).toBe(properties);
+  });
+
+  it("resolves databaseId to dataSourceId before dispatching update", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-456", data_sources: [{ id: "ds-123" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+
+    await getUpdateDataSource()(client as any, "db-456", { title: "Renamed" });
+
+    expect(client.databases.retrieve).toHaveBeenCalledWith({ database_id: "db-456" });
+    expect(client.dataSources.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data_source_id: "ds-123" }),
+    );
+  });
+
+  it("wraps title via rich text before sending", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-title", data_sources: [{ id: "ds-title" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+
+    await getUpdateDataSource()(client as any, "db-title", { title: "New name" });
+
+    expect(client.dataSources.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: [{ type: "text", text: { content: "New name" } }],
+      }),
+    );
+  });
+
+  it("forwards in_trash literally and never aliases archived", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-trash", data_sources: [{ id: "ds-trash" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+
+    await getUpdateDataSource()(client as any, "db-trash", { in_trash: true });
+
+    expect(client.dataSources.update).toHaveBeenCalledWith(
+      expect.objectContaining({ in_trash: true }),
+    );
+    expect(client.dataSources.update.mock.calls[0]?.[0]).not.toHaveProperty("archived");
+  });
+
+  it("throws on an empty updates object before any network call", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-empty", data_sources: [{ id: "ds-empty" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+
+    await expect(getUpdateDataSource()(client as any, "db-empty", {})).rejects.toThrow(
+      "updateDataSource: at least one of `title`, `properties`, or `in_trash` must be provided",
+    );
+    expect(client.databases.retrieve).not.toHaveBeenCalled();
+    expect(client.dataSources.update).not.toHaveBeenCalled();
+  });
+
+  it("preserves property delete via null", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-null", data_sources: [{ id: "ds-null" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+    const properties = { Legacy: null };
+
+    await getUpdateDataSource()(client as any, "db-null", { properties });
+
+    expect(client.dataSources.update).toHaveBeenCalledWith(
+      expect.objectContaining({ properties }),
+    );
+    expect(client.dataSources.update.mock.calls[0]?.[0]?.properties).toEqual({ Legacy: null });
+  });
+
+  it("passes property rename payloads through untouched", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-rename", data_sources: [{ id: "ds-rename" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+    const properties = { Old: { name: "New" } };
+
+    await getUpdateDataSource()(client as any, "db-rename", { properties });
+
+    expect(client.dataSources.update).toHaveBeenCalledWith(
+      expect.objectContaining({ properties }),
+    );
+  });
+
+  it("invalidates cached schema after a successful update but not after a failed update", async () => {
+    const successClient = makeMockClient({
+      dataSources: {
+        retrieve: vi
+          .fn()
+          .mockResolvedValueOnce({ id: "ds-cache-success", properties: { Name: { type: "title" } } })
+          .mockResolvedValueOnce({ id: "ds-cache-success", properties: { Name: { type: "rich_text" } } }),
+      } as Partial<MockClient["dataSources"]>,
+      databases: {
+        retrieve: vi
+          .fn()
+          .mockResolvedValue({ id: "db-cache-success", data_sources: [{ id: "ds-cache-success" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+
+    await notionClient.getCachedSchema(successClient as any, "db-cache-success");
+    expect(successClient.dataSources.retrieve).toHaveBeenCalledTimes(1);
+
+    await getUpdateDataSource()(successClient as any, "db-cache-success", { title: "Fresh schema" });
+    await notionClient.getCachedSchema(successClient as any, "db-cache-success");
+
+    expect(successClient.dataSources.retrieve).toHaveBeenCalledTimes(2);
+
+    const failedClient = makeMockClient({
+      dataSources: {
+        update: vi.fn().mockRejectedValue(new Error("boom")),
+        retrieve: vi
+          .fn()
+          .mockResolvedValueOnce({ id: "ds-cache-fail", properties: { Name: { type: "title" } } }),
+      } as Partial<MockClient["dataSources"]>,
+      databases: {
+        retrieve: vi
+          .fn()
+          .mockResolvedValue({ id: "db-cache-fail", data_sources: [{ id: "ds-cache-fail" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+
+    await notionClient.getCachedSchema(failedClient as any, "db-cache-fail");
+    expect(failedClient.dataSources.retrieve).toHaveBeenCalledTimes(1);
+
+    await expect(
+      getUpdateDataSource()(failedClient as any, "db-cache-fail", { title: "Should fail" }),
+    ).rejects.toThrow("boom");
+    await notionClient.getCachedSchema(failedClient as any, "db-cache-fail");
+
+    expect(failedClient.dataSources.retrieve).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createDatabase", () => {
+  it("still omits is_inline when options are not provided", async () => {
+    const client = makeMockClient();
+    const schema = [{ name: "Name", type: "title" }];
+
+    await notionClient.createDatabase(client as any, "parent-1", "Tasks", schema);
+
+    expect(client.databases.create).toHaveBeenCalledTimes(1);
+    const body = client.databases.create.mock.calls[0]?.[0];
+    expect(body).not.toHaveProperty("is_inline");
+    expect(body).toEqual(
+      expect.objectContaining({
+        parent: { type: "page_id", page_id: "parent-1" },
+        title: [{ type: "text", text: { content: "Tasks" } }],
+      }),
+    );
+  });
+
+  it("forwards is_inline: true when requested", async () => {
+    const client = makeMockClient();
+
+    await notionClient.createDatabase(
+      client as any,
+      "parent-inline-true",
+      "Inline true",
+      [{ name: "Name", type: "title" }],
+      { is_inline: true } as any,
+    );
+
+    expect(client.databases.create).toHaveBeenCalledWith(
+      expect.objectContaining({ is_inline: true }),
+    );
+  });
+
+  it("forwards is_inline: false when requested", async () => {
+    const client = makeMockClient();
+
+    await notionClient.createDatabase(
+      client as any,
+      "parent-inline-false",
+      "Inline false",
+      [{ name: "Name", type: "title" }],
+      { is_inline: false } as any,
+    );
+
+    expect(client.databases.create).toHaveBeenCalledWith(
+      expect.objectContaining({ is_inline: false }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `update_data_source` MCP tool, wrapping `client.dataSources.update()` for database schema mutation (rename properties, update select/status options, change title, trash a data source).
- Extends `create_database` to accept `is_inline` on creation (new optional `options` arg on the existing `createDatabase` wrapper, plus tool schema update).
- Invalidates the 5-minute schema cache on successful mutation — a correctness requirement, not an optimization.
- One coherent idea: extending the database mutation surface. No unrelated changes, no dependency bumps, no version bump.

## Why

- Notion officially added API support for creating and updating status properties on [2026-03-19](https://developers.notion.com/page/changelog). Until now, agents couldn't evolve a database's status options programmatically. The legacy reference pages still claim status is non-updatable — the changelog is authoritative.
- Property rename and option add/remove are the natural next step once `create_database` exists. Without them, schemas are effectively write-once.
- `is_inline` on create was a long-standing gap; adding it alongside is cheap and thematically aligned.

## Runtime evidence

Verified against a real Notion workspace during the build session: omit = remove (status options), cache invalidation, `is_inline` on create (`true` / `false` / omitted), and property rename all confirmed. Full payloads documented in `.meta/plans/update-data-source-tool-2026-04-10.md` §12.

### Unexpected finding — row reassignment on removed options

The runtime probe uncovered a Notion API behavior the plan did not anticipate: when `update_data_source` removes a status option that existing rows reference, Notion **silently reassigns those rows to the default group's first option** (e.g. `Not started`) — not rejected, not cleared, not dangling, no error raised.

This is destructive in disguise — an agent removing an option loses the semantic meaning on every row that had it, with no signal. A one-paragraph warning has been added to the `update_data_source` tool description (commit `c58325d`) calling this out explicitly and advising callers to reclassify referencing rows to an explicit target **before** removing an option from the schema.

A broader audit pass to discover silent-failure modes across the other wrappers has been tracked as a separate follow-up and will land in a subsequent PR.

## Scope explicitly excluded

- No `update_database` tool. Toggling `is_inline` on *existing* databases requires `client.databases.update()` (different endpoint, different body params) — tracked as a committed follow-up (see plan §9).
- No refactor of tool registration or `CreateServerConfig`.
- No new dependencies, no `package.json` changes, no version bump. A later release PR carries the version bump when the feature set is complete.

## Test plan

- [ ] CI green on Node 18 + 20
- [x] `npm run build` clean locally (tsc)
- [x] `npm test` clean locally (203 tests, 11 new in `tests/update-data-source.test.ts`)
- [x] Unit coverage for: raw `properties` pass-through, title wrapping, `in_trash` forwarding, property-delete via `null`, property-rename via `{ name }`, empty-update rejection, schema cache invalidation on success, `createDatabase` backwards-compat (no options), `createDatabase` with `is_inline: true` / `false`
- [x] Runtime evidence against a live Notion workspace (see plan §12)
