### PR TITLE
feat: add create_page_from_file tool and transport-conditional registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ src/
 - `NOTION_TOKEN` (required) — Notion internal integration token
 - `NOTION_ROOT_PAGE_ID` (optional) — default parent page
 - `NOTION_TRUST_CONTENT` (optional) — skip content notice prefix
+- `NOTION_MCP_WORKSPACE_ROOT` (optional, stdio only) — absolute path that bounds file_path inputs for the `create_page_from_file` tool. Defaults to the server's process.cwd(). Has no effect in HTTP mode.
 
 ### HTTP mode
 - `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET` — enables OAuth mode
@@ -131,3 +132,4 @@ These round-trip cleanly: `read_page` outputs the same conventions that `create_
 - **Schema caching** — database schemas are cached in-memory with a 5-minute TTL to avoid redundant API calls during batch operations
 - **`createServer` factory pattern** — decouples server setup from transport; in stdio mode the factory always returns the same client; in HTTP OAuth mode it returns a per-user client based on auth token
 - **OAuth relay** — the server acts as an MCP OAuth Authorization Server, redirects to Notion's OAuth consent screen, exchanges codes, and issues its own bearer tokens backed by encrypted file-based storage (AES-256-GCM)
+- **Transport-conditional tools** — tools can declare a `transports: ['stdio' | 'http']` list to restrict where they appear. Tools without the field are available in all transports. File-reading tools (e.g. `create_page_from_file`) are stdio-only because HTTP-mode callers don't share the server's filesystem.

--- a/src/http.ts
+++ b/src/http.ts
@@ -80,6 +80,7 @@ export async function createApp(options: CreateAppOptions = {}): Promise<express
           rootPageId: options.rootPageId,
           trustContent: options.trustContent ?? false,
           allowWorkspaceParent,
+          transport: "http",
         });
 
         await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ const server = createServer(
   {
     rootPageId: process.env.NOTION_ROOT_PAGE_ID,
     trustContent: process.env.NOTION_TRUST_CONTENT === "true",
+    transport: "stdio",
+    workspaceRoot: process.env.NOTION_MCP_WORKSPACE_ROOT || process.cwd(),
   }
 );
 

--- a/src/read-markdown-file.ts
+++ b/src/read-markdown-file.ts
@@ -1,0 +1,80 @@
+import { readFile, realpath, stat } from "node:fs/promises";
+import { isAbsolute, resolve as pathResolve, sep, extname } from "node:path";
+
+const MAX_FILE_BYTES = 1_048_576; // 1 MB
+const ALLOWED_EXTENSIONS = new Set([".md", ".markdown"]);
+
+export async function readMarkdownFile(
+  filePath: string,
+  workspaceRoot: string,
+): Promise<string> {
+  // 1. Absolute path check
+  if (!isAbsolute(filePath)) {
+    throw new Error(
+      `create_page_from_file: file_path must be an absolute path, got '${filePath}'`,
+    );
+  }
+
+  // 2. Resolve symlinks. realpath throws ENOENT if file doesn't exist.
+  let realFilePath: string;
+  let realWorkspaceRoot: string;
+  try {
+    realFilePath = await realpath(pathResolve(filePath));
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      throw new Error(`create_page_from_file: file not found: '${filePath}'`);
+    }
+    throw err;
+  }
+  try {
+    realWorkspaceRoot = await realpath(pathResolve(workspaceRoot));
+  } catch (err: any) {
+    throw new Error(
+      `create_page_from_file: configured workspace root does not resolve: '${workspaceRoot}'`,
+    );
+  }
+
+  // 3. Separator-aware containment check
+  const rootWithSep = realWorkspaceRoot.endsWith(sep)
+    ? realWorkspaceRoot
+    : realWorkspaceRoot + sep;
+  if (
+    realFilePath !== realWorkspaceRoot &&
+    !realFilePath.startsWith(rootWithSep)
+  ) {
+    throw new Error(
+      `create_page_from_file: file_path '${filePath}' resolves outside the allowed workspace root`,
+    );
+  }
+
+  // 4. Extension check on RESOLVED path
+  const realExt = extname(realFilePath).toLowerCase();
+  if (!ALLOWED_EXTENSIONS.has(realExt)) {
+    throw new Error(
+      `create_page_from_file: file must have .md or .markdown extension (resolved path: '${realFilePath}')`,
+    );
+  }
+
+  // 5. Regular-file check + size cap
+  const stats = await stat(realFilePath);
+  if (!stats.isFile()) {
+    throw new Error(
+      `create_page_from_file: not a regular file: '${filePath}'`,
+    );
+  }
+  if (stats.size > MAX_FILE_BYTES) {
+    throw new Error(
+      `create_page_from_file: file size ${stats.size} exceeds ${MAX_FILE_BYTES}-byte cap`,
+    );
+  }
+
+  // 6. Strict UTF-8 decode (readFile("utf8") silently replaces bad bytes)
+  const buf = await readFile(realFilePath);
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(buf);
+  } catch (err: any) {
+    throw new Error(
+      `create_page_from_file: file is not valid UTF-8: '${filePath}'`,
+    );
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import {
 import { blocksToMarkdown } from "./blocks-to-markdown.js";
 import { processFileUploads } from "./file-upload.js";
 import { blockTextToRichText, markdownToBlocks } from "./markdown-to-blocks.js";
+import { readMarkdownFile } from "./read-markdown-file.js";
 import {
   addComment,
   appendBlocks,
@@ -413,6 +414,13 @@ function enhanceError(error: unknown, toolName: string, args: Record<string, unk
   return message;
 }
 
+type ToolDefinition = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  transports?: readonly [ServerTransport, ...ServerTransport[]];
+};
+
 const tools = [
   {
     name: "create_page",
@@ -449,6 +457,38 @@ const tools = [
       },
       required: ["title", "markdown"],
     },
+  },
+  {
+    name: "create_page_from_file",
+    description: `Create a Notion page from a local markdown file. The server reads the file, validates it, and creates the page — identical result to calling create_page, without shipping the file's content through the agent's context window.
+
+STDIO MODE ONLY. This tool is not available when the server runs over HTTP, because in HTTP mode the server's filesystem belongs to the server host, not the caller.
+
+Restrictions:
+- file_path must be an ABSOLUTE path (no relative paths, no ~ expansion)
+- File must be inside the configured workspace root (defaults to the server's process.cwd(); override via the NOTION_MCP_WORKSPACE_ROOT env var)
+- File extension must be .md or .markdown
+- File size must be ≤ 1 MB (1,048,576 bytes)
+- File must be valid UTF-8
+- Symlinks are resolved and the resolved path must still be inside the workspace root
+
+Same markdown syntax as create_page (headings, tables, callouts, toggles, columns, bookmarks, task lists, etc.).`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Page title" },
+        file_path: {
+          type: "string",
+          description: "Absolute path to a local .md or .markdown file (≤ 1 MB, UTF-8, inside the configured workspace root)",
+        },
+        parent_page_id: {
+          type: "string",
+          description: "Parent page ID. Same resolution rules as create_page.",
+        },
+      },
+      required: ["title", "file_path"],
+    },
+    transports: ["stdio"] as const,
   },
   {
     name: "append_content",
@@ -823,19 +863,29 @@ Call get_database first to see available properties and valid options.`,
       properties: {},
     },
   },
-] as const;
+] as const satisfies readonly ToolDefinition[];
+
+export type ServerTransport = "stdio" | "http";
 
 export interface CreateServerConfig {
   rootPageId?: string;
   trustContent?: boolean;
   allowWorkspaceParent?: boolean;
+  transport?: ServerTransport;
+  workspaceRoot?: string;
 }
 
 export function createServer(
   notionClientFactory: () => ReturnType<typeof createNotionClient>,
   config: CreateServerConfig = {},
 ): Server {
-  const { rootPageId, trustContent = false, allowWorkspaceParent = false } = config;
+  const {
+    rootPageId,
+    trustContent = false,
+    allowWorkspaceParent = false,
+    transport = "stdio",
+    workspaceRoot,
+  } = config;
   let stickyParentPageId: string | undefined;
 
   const server = new Server(
@@ -874,11 +924,25 @@ export function createServer(
   }
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: [...tools] };
+    const visible = (tools as readonly ToolDefinition[])
+      .filter((tool) => !tool.transports || tool.transports.includes(transport))
+      .map(({ name, description, inputSchema }) => ({
+        name,
+        description,
+        inputSchema,
+      }));
+    return { tools: visible };
   });
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
+
+    const toolDef = (tools as readonly ToolDefinition[]).find((tool) => tool.name === name);
+    if (toolDef?.transports && !toolDef.transports.includes(transport)) {
+      return textResponse({
+        error: `Tool '${name}' is not available in '${transport}' transport mode.`,
+      });
+    }
 
     try {
       switch (name) {
@@ -901,6 +965,38 @@ export function createServer(
             icon,
             cover,
           ) as any;
+          const response: Record<string, unknown> = {
+            id: page.id,
+            title,
+            url: page.url,
+          };
+          if (parent.type === "workspace") {
+            response.note = "Created as a private workspace page. Use move_page to relocate.";
+          }
+          return textResponse(response);
+        }
+        case "create_page_from_file": {
+          if (!workspaceRoot) {
+            return textResponse({
+              error: "create_page_from_file requires workspaceRoot to be configured on the server. This tool is stdio-only.",
+            });
+          }
+          const notion = notionClientFactory();
+          const { title, file_path, parent_page_id } = args as {
+            title: string;
+            file_path: string;
+            parent_page_id?: string;
+          };
+
+          const parent = await resolveParent(notion, parent_page_id);
+          const markdown = await readMarkdownFile(file_path, workspaceRoot);
+          const page = await createPage(
+            notion,
+            parent,
+            title,
+            markdownToBlocks(markdown),
+          ) as any;
+
           const response: Record<string, unknown> = {
             id: page.id,
             title,

--- a/tests/create-page-from-file.test.ts
+++ b/tests/create-page-from-file.test.ts
@@ -1,0 +1,426 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockReadMarkdownFile } = vi.hoisted(() => ({
+  mockReadMarkdownFile: vi.fn(),
+}));
+
+vi.mock("../src/notion-client.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/notion-client.js")>(
+    "../src/notion-client.js",
+  );
+
+  return {
+    ...actual,
+    createPage: vi.fn(),
+    findWorkspacePages: vi.fn(),
+  };
+});
+
+vi.mock("../src/read-markdown-file.js", () => ({
+  readMarkdownFile: mockReadMarkdownFile,
+}));
+
+import { createPage, findWorkspacePages } from "../src/notion-client.js";
+import { readMarkdownFile } from "../src/read-markdown-file.ts";
+import { createServer, type CreateServerConfig } from "../src/server.js";
+
+type TestServerConfig = CreateServerConfig & {
+  transport?: "stdio" | "http";
+  workspaceRoot?: string;
+};
+
+function parseToolText(result: { content?: Array<{ type: string; text?: string }> }) {
+  const text = result.content?.find((item) => item.type === "text")?.text;
+  if (!text) {
+    throw new Error("Expected text content in tool result");
+  }
+  return text;
+}
+
+function parseToolResult(result: { content?: Array<{ type: string; text?: string }> }) {
+  return JSON.parse(parseToolText(result)) as Record<string, unknown>;
+}
+
+async function createConnectedClient(config: TestServerConfig = {}) {
+  const notion = {};
+  const server = createServer(() => notion as any, config as CreateServerConfig);
+  const client = new McpClient(
+    { name: "create-page-from-file-test", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return {
+    client,
+    async close() {
+      await Promise.all([
+        clientTransport.close(),
+        serverTransport.close(),
+      ]);
+    },
+  };
+}
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string) {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("create_page_from_file", () => {
+  beforeEach(() => {
+    vi.mocked(createPage).mockResolvedValue({
+      id: "new-page-id",
+      url: "https://notion.so/new-page",
+    } as any);
+    vi.mocked(findWorkspacePages).mockResolvedValue([]);
+    mockReadMarkdownFile.mockReset();
+    mockReadMarkdownFile.mockResolvedValue("# Placeholder");
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  describe("readMarkdownFile", () => {
+    let realReadMarkdownFile: typeof readMarkdownFile;
+
+    beforeEach(async () => {
+      const actual = await vi.importActual<typeof import("../src/read-markdown-file.js")>(
+        "../src/read-markdown-file.js",
+      );
+      realReadMarkdownFile = actual.readMarkdownFile;
+    });
+
+    it("reads a valid .md file inside the allowed root", async () => {
+      const rootDir = await makeTempDir("read-markdown-file-root-");
+      const filePath = join(rootDir, "note.md");
+
+      await writeFile(filePath, "# Hello\nWorld");
+
+      await expect(realReadMarkdownFile(filePath, rootDir)).resolves.toBe("# Hello\nWorld");
+    });
+
+    it("rejects relative paths", async () => {
+      const rootDir = await makeTempDir("read-markdown-file-root-");
+
+      await expect(realReadMarkdownFile("./foo.md", rootDir)).rejects.toThrow(/absolute path/i);
+    });
+
+    it("rejects paths outside the allowed root", async () => {
+      const allowedRoot = await makeTempDir("read-markdown-file-allowed-");
+      const otherRoot = await makeTempDir("read-markdown-file-other-");
+      const filePath = join(otherRoot, "outside.md");
+
+      await writeFile(filePath, "# Outside");
+
+      await expect(realReadMarkdownFile(filePath, allowedRoot)).rejects.toThrow(/allowed root|outside/i);
+    });
+
+    it("rejects non-existent files with a clean error", async () => {
+      const rootDir = await makeTempDir("read-markdown-file-root-");
+      const filePath = join(rootDir, "missing.md");
+
+      await expect(realReadMarkdownFile(filePath, rootDir)).rejects.toThrow(/file not found/i);
+    });
+
+    it("rejects files larger than 1,048,576 bytes", async () => {
+      const rootDir = await makeTempDir("read-markdown-file-root-");
+      const filePath = join(rootDir, "too-large.md");
+
+      await writeFile(filePath, Buffer.alloc(1_048_577, 0x61));
+
+      await expect(realReadMarkdownFile(filePath, rootDir)).rejects.toThrow(/1048576-byte cap|exceeds/i);
+    });
+
+    it("accepts files up to 1,048,576 bytes", async () => {
+      const rootDir = await makeTempDir("read-markdown-file-root-");
+      const filePath = join(rootDir, "max-size.md");
+
+      await writeFile(filePath, Buffer.alloc(1_048_576, 0x61));
+
+      await expect(realReadMarkdownFile(filePath, rootDir)).resolves.toBe("a".repeat(1_048_576));
+    });
+
+    it("rejects binary files that are not valid UTF-8", async () => {
+      const rootDir = await makeTempDir("read-markdown-file-root-");
+      const filePath = join(rootDir, "binary.md");
+
+      await writeFile(filePath, Buffer.from([0xFF, 0xFE, 0x00]));
+
+      await expect(realReadMarkdownFile(filePath, rootDir)).rejects.toThrow(/not valid UTF-8/i);
+    });
+
+    it("rejects symlinks that escape the allowed root", async () => {
+      const allowedRoot = await makeTempDir("read-markdown-file-allowed-");
+      const escapedRoot = await makeTempDir("read-markdown-file-escaped-");
+      const escapedFile = join(escapedRoot, "escaped.md");
+      const symlinkPath = join(allowedRoot, "link.md");
+
+      await writeFile(escapedFile, "# Escaped");
+      await symlink(escapedFile, symlinkPath);
+
+      await expect(realReadMarkdownFile(symlinkPath, allowedRoot)).rejects.toThrow(/allowed root|outside/i);
+    });
+
+    it.each([
+      "notes.txt",
+      "data.json",
+      "README",
+    ])("rejects disallowed extension %s", async (filename) => {
+      const rootDir = await makeTempDir("read-markdown-file-root-");
+      const filePath = join(rootDir, filename);
+
+      await writeFile(filePath, "content");
+
+      await expect(realReadMarkdownFile(filePath, rootDir)).rejects.toThrow(/extension|\.md/i);
+    });
+
+    it("uses separator-aware containment instead of naive prefix matching", async () => {
+      const parentDir = await makeTempDir("read-markdown-file-parent-");
+      const allowedRoot = join(parentDir, "root");
+      const siblingRoot = join(parentDir, "rootbar");
+      const filePath = join(siblingRoot, "file.md");
+
+      await mkdir(allowedRoot);
+      await mkdir(siblingRoot);
+      await writeFile(filePath, "# Wrong root");
+
+      await expect(realReadMarkdownFile(filePath, allowedRoot)).rejects.toThrow(/allowed root|outside/i);
+    });
+  });
+
+  describe("transport filtering", () => {
+    it("lists create_page_from_file in stdio mode", async () => {
+      const { client, close } = await createConnectedClient({
+        transport: "stdio",
+        workspaceRoot: "/tmp",
+      });
+
+      try {
+        const result = await client.listTools();
+        const toolNames = result.tools.map((tool) => tool.name);
+
+        expect(toolNames).toContain("create_page_from_file");
+        expect(result.tools).toHaveLength(28);
+      } finally {
+        await close();
+      }
+    });
+
+    it("does not list create_page_from_file in http mode", async () => {
+      const { client, close } = await createConnectedClient({ transport: "http" });
+
+      try {
+        const result = await client.listTools();
+        const toolNames = result.tools.map((tool) => tool.name);
+
+        expect(toolNames).not.toContain("create_page_from_file");
+        expect(result.tools).toHaveLength(27);
+      } finally {
+        await close();
+      }
+    });
+
+    it("keeps http tools equal to stdio tools minus create_page_from_file", async () => {
+      const stdioConnection = await createConnectedClient({
+        transport: "stdio",
+        workspaceRoot: "/tmp",
+      });
+      const httpConnection = await createConnectedClient({ transport: "http" });
+
+      try {
+        const stdioTools = await stdioConnection.client.listTools();
+        const httpTools = await httpConnection.client.listTools();
+        const stdioToolNames = new Set(stdioTools.tools.map((tool) => tool.name));
+        const httpToolNames = new Set(httpTools.tools.map((tool) => tool.name));
+
+        stdioToolNames.delete("create_page_from_file");
+
+        expect(httpToolNames).toEqual(stdioToolNames);
+        expect(stdioTools.tools).toHaveLength(httpTools.tools.length + 1);
+
+        for (const sharedTool of ["create_page", "read_page", "search", "update_data_source"]) {
+          expect(httpToolNames).toContain(sharedTool);
+          expect(new Set(stdioTools.tools.map((tool) => tool.name))).toContain(sharedTool);
+        }
+      } finally {
+        await Promise.all([
+          stdioConnection.close(),
+          httpConnection.close(),
+        ]);
+      }
+    });
+
+    it("defaults to stdio transport when transport is omitted", async () => {
+      const { client, close } = await createConnectedClient({ workspaceRoot: "/tmp" });
+
+      try {
+        const result = await client.listTools();
+        const toolNames = result.tools.map((tool) => tool.name);
+
+        expect(toolNames).toContain("create_page_from_file");
+      } finally {
+        await close();
+      }
+    });
+
+    it("returns a transport-specific error when called in http mode", async () => {
+      const { client, close } = await createConnectedClient({ transport: "http" });
+
+      try {
+        const result = await client.callTool({
+          name: "create_page_from_file",
+          arguments: {
+            title: "From file",
+            file_path: "/tmp/note.md",
+            parent_page_id: "parent-123",
+          },
+        });
+
+        expect(parseToolText(result)).toContain("not available in 'http' transport mode");
+        expect(createPage).not.toHaveBeenCalled();
+      } finally {
+        await close();
+      }
+    });
+
+    it("does not leak transports metadata in listTools responses", async () => {
+      const { client, close } = await createConnectedClient({
+        transport: "stdio",
+        workspaceRoot: "/tmp",
+      });
+
+      try {
+        const result = await client.listTools();
+
+        for (const tool of result.tools) {
+          expect(Object.keys(tool).sort()).toEqual(["description", "inputSchema", "name"]);
+          expect(tool).not.toHaveProperty("transports");
+        }
+      } finally {
+        await close();
+      }
+    });
+
+    it("preserves create_database.is_inline in the listed schema", async () => {
+      const { client, close } = await createConnectedClient({ transport: "http" });
+
+      try {
+        const result = await client.listTools();
+        const createDatabaseTool = result.tools.find((tool) => tool.name === "create_database");
+
+        expect(createDatabaseTool).toBeDefined();
+        expect(createDatabaseTool?.inputSchema).toMatchObject({
+          properties: {
+            is_inline: expect.any(Object),
+          },
+        });
+      } finally {
+        await close();
+      }
+    });
+  });
+
+  describe("create_page_from_file handler", () => {
+    it("creates a page from markdown read from a local file", async () => {
+      mockReadMarkdownFile.mockResolvedValue("# Hello\nWorld");
+      vi.mocked(createPage).mockResolvedValue({
+        id: "page-123",
+        url: "https://notion.so/page",
+      } as any);
+
+      const { client, close } = await createConnectedClient({
+        transport: "stdio",
+        workspaceRoot: "/tmp",
+      });
+
+      try {
+        const result = await client.callTool({
+          name: "create_page_from_file",
+          arguments: {
+            title: "Imported from file",
+            file_path: "/tmp/import.md",
+            parent_page_id: "parent-123",
+          },
+        });
+
+        expect(mockReadMarkdownFile).toHaveBeenCalledWith("/tmp/import.md", "/tmp");
+        expect(createPage).toHaveBeenCalledWith(
+          expect.anything(),
+          { type: "page_id", page_id: "parent-123" },
+          "Imported from file",
+          expect.any(Array),
+        );
+
+        const response = parseToolResult(result);
+        expect(response.id).toBe("page-123");
+        expect(response.url).toBe("https://notion.so/page");
+      } finally {
+        await close();
+      }
+    });
+
+    it("returns an error when workspaceRoot is not configured", async () => {
+      const { client, close } = await createConnectedClient({ transport: "stdio" });
+
+      try {
+        const result = await client.callTool({
+          name: "create_page_from_file",
+          arguments: {
+            title: "Imported from file",
+            file_path: "/tmp/import.md",
+            parent_page_id: "parent-123",
+          },
+        });
+
+        expect(parseToolText(result)).toContain("workspaceRoot");
+      } finally {
+        await close();
+      }
+    });
+
+    it("propagates readMarkdownFile errors to the tool response", async () => {
+      mockReadMarkdownFile.mockRejectedValue(new Error("file not found"));
+
+      const { client, close } = await createConnectedClient({
+        transport: "stdio",
+        workspaceRoot: "/tmp",
+      });
+
+      try {
+        const result = await client.callTool({
+          name: "create_page_from_file",
+          arguments: {
+            title: "Imported from file",
+            file_path: "/tmp/missing.md",
+            parent_page_id: "parent-123",
+          },
+        });
+
+        expect(parseToolText(result)).toContain("file not found");
+      } finally {
+        await close();
+      }
+    });
+  });
+});

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -142,6 +142,7 @@ describe("HTTP Transport — Static Token Mode", () => {
     expect(toolNames).toContain("read_page");
     expect(toolNames).toContain("search");
     expect(toolNames).toContain("update_data_source");
+    expect(toolNames).not.toContain("create_page_from_file");
   });
 
   it("returns 400 for GET /mcp without a session", async () => {


### PR DESCRIPTION
## Summary

- Adds `create_page_from_file` MCP tool — reads a markdown file server-side and pipes it through the existing page-creation path. Agent context only sees three short strings (parent id, title, file path) instead of the full file content.
- Introduces **transport-conditional tool registration** on `CreateServerConfig` — tools can now declare which transports they're available in (`stdio`, `http`, or both). Tools that don't declare stay available everywhere (zero-touch for the existing 27 tools).
- `create_page_from_file` is registered as `stdio`-only. In HTTP/OAuth mode, the tool doesn't appear in `list_tools` and calls return a clear transport error.
- New `src/read-markdown-file.ts` module handles file reading + security validation, separate from `notion-client.ts` (which stays purely for Notion SDK wrappers).

## Why

- Measured pain: a prior session burned ~90-150K tokens of agent context transferring 24 markdown files into Notion via `Read` + `create_page(content=...)`. The content passes through context twice for purely mechanical work. The file-based variant eliminates that cost entirely.
- The transport-gating infrastructure is needed because this tool is only meaningful in stdio mode (server's filesystem = caller's filesystem). In HTTP mode, caller-specified file paths are meaningless and would be a security gap. The infrastructure is reusable — any future tool that's only meaningful locally gets the same hook.

## Security restrictions

The file-reading path enforces:
- **Absolute paths only** — relative paths rejected
- **Workspace-root gating** — `fs.realpath` resolves the path, then checks it's under `NOTION_MCP_WORKSPACE_ROOT` (env var, defaults to `process.cwd()`)
- **Symlink escape prevention** — realpath resolution before root check defeats symlinks that point outside the allowed root
- **1 MB file size cap**
- **UTF-8 validation** — `TextDecoder('utf-8', { fatal: true })` on a raw Buffer, not `fs.readFile(path, 'utf-8')` which silently replaces invalid bytes with U+FFFD
- **Extension check** — `.md` and `.markdown` only, checked on the resolved real path

## Runtime evidence

Verified against a real Notion workspace. Full payloads documented in `.meta/plans/create-page-from-file-2026-04-15.md`.

- **Happy path:** 12 block types round-trip confirmed (headings, lists, code, callout, toggle, tasks, table)
- **Security:** 6/6 restrictions enforced — outside-root, relative path, non-existent, oversize, binary, wrong extension all rejected with clear errors, zero side effects on the sandbox
- **Transport filtering:** stdio mode lists 28 tools (includes `create_page_from_file`), HTTP mode lists 27 (excludes it), HTTP-mode call returns `"Tool 'create_page_from_file' is not available in 'http' transport mode."`

## Scope explicitly excluded

- No `create_database_from_file` or other `_from_file` variants — one tool, one coherent idea
- No refactor of the markdown-to-blocks pipeline
- No new dependencies, no `package.json` changes, no version bump

## Test plan

- [ ] CI green on Node 18 + 20
- [x] `npm run build` clean locally (tsc)
- [x] `npm test` clean locally (225 tests across 13 files, 22 new)
- [x] Security restriction tests: path validation, size cap, UTF-8 validation, extension check, symlink escape
- [x] Transport filtering tests: stdio includes tool, HTTP excludes it, HTTP call errors cleanly, existing 27 tools unaffected in both modes
- [x] Runtime evidence against a live Notion workspace (see plan file)
