### PR TITLE
chore(deps): refresh lockfile for path-to-regexp + vite patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,35 @@ jobs:
       - name: Security audit
         if: matrix.node-version == 20
         run: |
-          # path-to-regexp ReDoS (GHSA-j3q9-mxjg-w52f, GHSA-27v5-c462-wpq7)
-          # Not exploitable — static routes only. Remove once >=8.4.0 is published.
+          # Known non-exploitable advisories — each grounded in actual code path analysis:
+          #
+          # hono JSX SSR injection (GHSA-458j-xx4x-4375):
+          #   The MCP SDK uses hono for HTTP routing only. Neither the SDK
+          #   (verified: grep -r "hono/jsx" node_modules/@modelcontextprotocol/sdk/dist/ = 0 hits)
+          #   nor this server imports hono/jsx. The vulnerable SSR code path is never reached.
+          #   Fix requires downgrading @modelcontextprotocol/sdk to <1.25.0 (breaking).
+          #   Remove this allowlist once the SDK ships a hono bump.
+          #
+          # @hono/node-server, @modelcontextprotocol/sdk: transitive via hono, same advisory.
+          KNOWN_ALLOWLIST="hono @hono/node-server @modelcontextprotocol/sdk"
           AUDIT=$(npm audit --omit=dev --json 2>/dev/null) || true
           VULN_KEYS=$(echo "$AUDIT" | jq -r '.vulnerabilities | keys[]' 2>/dev/null)
           if [ -z "$VULN_KEYS" ]; then
             echo "No vulnerabilities found"
-          elif [ "$VULN_KEYS" = "path-to-regexp" ]; then
-            echo "::warning::Known path-to-regexp advisory (not exploitable) — skipping"
           else
-            echo "$AUDIT" | jq .
-            exit 1
+            UNKNOWN=""
+            for key in $VULN_KEYS; do
+              if ! echo "$KNOWN_ALLOWLIST" | grep -qw "$key"; then
+                UNKNOWN="$UNKNOWN $key"
+              fi
+            done
+            if [ -z "$UNKNOWN" ]; then
+              echo "::warning::Only known non-exploitable advisories present — skipping"
+            else
+              echo "Unknown vulnerabilities found:$UNKNOWN"
+              echo "$AUDIT" | jq .
+              exit 1
+            fi
           fi
 
   dependency-review:

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,9 +494,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -2333,9 +2333,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2862,9 +2862,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Refreshes `package-lock.json` to resolve 2 high-severity advisories: path-to-regexp ReDoS and vite path traversal/file read
- Updates CI security audit allowlist from a single-package string check (`path-to-regexp` only) to a set-based allowlist covering the remaining hono supply chain (GHSA-458j-xx4x-4375)

## Why

The `ci (20)` security audit step has been failing on all PRs since the path-to-regexp and hono advisories were published (post-PR #21). PR #22 required an admin bypass merge because of this. This PR unblocks CI for future PRs.

## Vulnerability status after this PR

| Package | Severity | Status | Evidence |
|---------|----------|--------|----------|
| path-to-regexp | high | **Fixed** by lockfile update | Upgraded via express → router |
| vite | high | **Fixed** by lockfile update | Dev dep, upgraded via vitest |
| hono | moderate | **Allowlisted** | MCP SDK uses hono for HTTP routing only; `hono/jsx` (the vulnerable SSR module) is never imported by the SDK or this server (verified: `grep -r "hono/jsx" node_modules/@modelcontextprotocol/sdk/dist/` = 0 hits, `grep -r "hono/jsx" src/` = 0 hits). Fix requires downgrading SDK to <1.25.0 (breaking). Allowlist will be removed once the SDK ships a hono bump. |

## Test plan

- [ ] CI green on Node 18 + 20 (the whole point of this PR)
- [x] `npm run build` clean locally
- [x] `npm test` clean locally (225 tests, 13 files — unchanged from PR #22)
