### PR TITLE
chore(deps): patch transitive hono for GHSA-458j-xx4x-4375

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-notion-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-notion-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -2016,9 +2016,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

Refreshes `package-lock.json` to pick up `hono@4.12.14`, which patches [GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375) — an XSS via improper JSX attribute name handling in `hono/jsx` SSR (moderate, CVSS 4.3). This follows the same lockfile-only shape as #19.

**Dependabot alert:** [#12](https://github.com/Grey-Iris/easy-notion-mcp/security/dependabot/12)

## What changed

```diff
 "node_modules/hono": {
-  "version": "4.12.12",
-  "resolved": ".../hono-4.12.12.tgz",
-  "integrity": "sha512-p1JfQM..."
+  "version": "4.12.14",
+  "resolved": ".../hono-4.12.14.tgz",
+  "integrity": "sha512-am5zfg..."
```

Plus a lockfile header metadata correction (`0.3.0 → 0.3.1`) that npm auto-applied during the refresh to match the already-bumped `package.json` version. No `package.json` diff.

Full: `package-lock.json | 10 +++++----- / 1 file changed, 5 insertions(+), 5 deletions(-)`

## Why lockfile-only (not overrides / SDK bump)

Same audit-backed reasoning as #19 (see [`.meta/audits/hono-supply-chain-2026-04-09.md`](.meta/audits/hono-supply-chain-2026-04-09.md)):

- **`overrides` in our `package.json`**: only honored at the *consumer's* root per [npm docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json/) — would fix our CI only, not downstream users.
- **Bumping `@modelcontextprotocol/sdk`**: every 1.x SDK version still pins `hono: ^4.11.4`, so this is a no-op.
- **Lockfile refresh (this PR)**: the SDK's caret range already permits `hono@4.12.14`. `npm update hono` does it in one shot.

End-user impact: **none.** We don't publish `package-lock.json` to npm. A consumer installing `easy-notion-mcp` fresh today already resolves to `hono@4.12.14` via the SDK's caret range. The only place carrying the vulnerable version was our committed lockfile, which affects only our own CI.

## Evidence we don't use the vulnerable code path

```
$ grep -rn "hono" src/
(no matches)
```

GHSA-458j-xx4x-4375 is specific to `hono/jsx` SSR — we import zero symbols from `hono` or `@hono/node-server` directly in `src/`. The SDK's transitive hono usage is limited to `getRequestListener` from `@hono/node-server` (per the prior audit, §Q1), which doesn't touch the JSX SSR code path. Patching anyway per CLAUDE.md's "patch rather than whitelist on reasoning" rule — "theoretically safe" isn't the bar for a server users hand their Notion workspace token to.

## Upstream

Filed [modelcontextprotocol/typescript-sdk#1941](https://github.com/modelcontextprotocol/typescript-sdk/issues/1941) asking for `hono@4.12.14` to be included in the next transitive bump (Dependabot PR #1894 covers `@hono/node-server` 1.19.13 but missed `hono` core, likely because `4.12.14` post-dates the scan window).

## `npm audit` — before / after

Before (on `dev`):
```json
[
  {
    "key": "hono",
    "value": {
      "via": [{ "url": "https://github.com/advisories/GHSA-458j-xx4x-4375", "range": "<4.12.14" }],
      "severity": "moderate"
    }
  }
]
```

After (this branch):
```json
[]
```

## Test plan

- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 22 passed | 1 skipped (23 files), 302 passed | 13 skipped (315 tests), 10.29s
- [x] `npm run test:e2e` — 2 files / 14 tests passed, 35.03s (live Notion API)
- [x] `npm audit` for `hono` — empty post-refresh
- [ ] CI green on this branch
