### PR TITLE
feat(properties): close Notion property-type gap

### DIFF
--- a/src/notion-client.ts
+++ b/src/notion-client.ts
@@ -39,6 +39,70 @@ function titleRichText(content: string) {
 
 type PropertiesUpdate = UpdateDataSourceParameters["properties"];
 
+export type SchemaEntry = {
+  name: string;
+  type: string;
+  [extra: string]: unknown;
+};
+
+const VALID_SCHEMA_TYPES = [
+  "title",
+  "rich_text",
+  "text",
+  "number",
+  "select",
+  "multi_select",
+  "status",
+  "date",
+  "checkbox",
+  "url",
+  "email",
+  "phone",
+  "formula",
+  "rollup",
+  "relation",
+  "unique_id",
+  "people",
+  "files",
+  "verification",
+  "place",
+  "location",
+  "button",
+  "created_time",
+  "last_edited_time",
+  "created_by",
+  "last_edited_by",
+] as const;
+const VALID_SCHEMA_TYPES_SET = new Set<string>(VALID_SCHEMA_TYPES);
+const RAW_PROPERTY_SHAPE_KEYS = new Set([
+  "title",
+  "rich_text",
+  "number",
+  "select",
+  "multi_select",
+  "status",
+  "date",
+  "checkbox",
+  "url",
+  "email",
+  "phone_number",
+  "formula",
+  "rollup",
+  "relation",
+  "people",
+  "files",
+  "unique_id",
+  "verification",
+  "place",
+  "button",
+  "location",
+  "created_time",
+  "last_edited_time",
+  "created_by",
+  "last_edited_by",
+  "name",
+]);
+
 const schemaCache = new Map<string, { schema: any; expires: number }>();
 const dataSourceIdCache = new Map<string, { dsId: string; expires: number }>();
 const SCHEMA_CACHE_TTL = 5 * 60 * 1000;
@@ -118,6 +182,31 @@ export async function getDatabase(client: Client, dbId: string) {
       prop.options = config.multi_select.options.map((o: any) => o.name);
     } else if (config.type === "status" && config.status?.options) {
       prop.options = config.status.options.map((o: any) => o.name);
+    } else if (config.type === "formula" && config.formula?.expression !== undefined) {
+      prop.expression = config.formula.expression;
+    } else if (config.type === "relation") {
+      if (config.relation?.data_source_id !== undefined) {
+        prop.data_source_id = config.relation.data_source_id;
+      }
+      if (config.relation?.type !== undefined) {
+        prop.relation_type = config.relation.type;
+      }
+    } else if (config.type === "rollup") {
+      if (config.rollup?.function !== undefined) {
+        prop.function = config.rollup.function;
+      }
+      if (config.rollup?.relation_property_name ?? config.rollup?.relation_property_id) {
+        prop.relation_property =
+          config.rollup.relation_property_name ?? config.rollup.relation_property_id;
+      }
+      if (config.rollup?.rollup_property_name ?? config.rollup?.rollup_property_id) {
+        prop.rollup_property =
+          config.rollup.rollup_property_name ?? config.rollup.rollup_property_id;
+      }
+    } else if (config.type === "unique_id" && config.unique_id?.prefix !== undefined) {
+      prop.prefix = config.unique_id.prefix;
+    } else if (config.type === "number" && config.number?.format !== undefined) {
+      prop.format = config.number.format;
     }
     return prop;
   });
@@ -142,26 +231,110 @@ export async function buildTextFilter(client: Client, dbId: string, text: string
   return { or: textProps };
 }
 
-export function schemaToProperties(schema: Array<{ name: string; type: string }>) {
+function validTypeList() {
+  return VALID_SCHEMA_TYPES.join(", ");
+}
+
+function invalidSchemaTypeError(name: string, type: string) {
+  return new Error(
+    `Property "${name}" has type "${type}", which is not a valid Notion property type. ` +
+      `Valid types: ${validTypeList()}.`,
+  );
+}
+
+function normalizeSchemaOptions(name: string, options: unknown) {
+  if (options === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(options)) {
+    throw new Error(`Property "${name}" must provide options as an array.`);
+  }
+
+  return options.map((option) => {
+    if (typeof option === "string") {
+      return { name: option };
+    }
+    if (option && typeof option === "object" && !Array.isArray(option)) {
+      const { name: optionName, color, description } = option as Record<string, unknown>;
+      if (typeof optionName !== "string" || optionName.length === 0) {
+        throw new Error(`Property "${name}" has an option without a valid name.`);
+      }
+      const normalized: Record<string, unknown> = { name: optionName };
+      if (color !== undefined) normalized.color = color;
+      if (description !== undefined) normalized.description = description;
+      return normalized;
+    }
+    throw new Error(`Property "${name}" has an invalid option. Use a string or {name, color, description}.`);
+  });
+}
+
+async function maybeResolveSchemaDataSourceId(client: Client, value: string) {
+  try {
+    return await getDataSourceId(client, value);
+  } catch {
+    return value;
+  }
+}
+
+async function resolveRelationDataSourceIds(client: Client, schema: SchemaEntry[], props: Record<string, any>) {
+  for (const entry of schema) {
+    if (entry.type !== "relation") {
+      continue;
+    }
+    const dataSourceId = entry.data_source_id;
+    if (typeof dataSourceId === "string" && props[entry.name]?.relation) {
+      props[entry.name].relation.data_source_id = await maybeResolveSchemaDataSourceId(client, dataSourceId);
+    }
+  }
+  return props;
+}
+
+function isSchemaShapePropertiesMap(properties: Record<string, unknown>) {
+  return Object.values(properties).every((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const record = value as Record<string, unknown>;
+    if (typeof record.type !== "string" || !VALID_SCHEMA_TYPES_SET.has(record.type)) {
+      return false;
+    }
+    return !Object.keys(record).some((key) => key !== "type" && RAW_PROPERTY_SHAPE_KEYS.has(key));
+  });
+}
+
+export function schemaToProperties(schema: SchemaEntry[]) {
   const props: Record<string, any> = {};
 
-  for (const { name, type } of schema) {
+  for (const entry of schema) {
+    const { name, type } = entry;
     switch (type) {
       case "title":
         props[name] = { title: {} };
         break;
+      case "rich_text":
       case "text":
         props[name] = { rich_text: {} };
         break;
-      case "number":
-        props[name] = { number: {} };
+      case "number": {
+        const format = entry.format;
+        props[name] = { number: format !== undefined ? { format } : {} };
         break;
-      case "select":
-        props[name] = { select: {} };
+      }
+      case "select": {
+        const options = normalizeSchemaOptions(name, entry.options);
+        props[name] = { select: options ? { options } : {} };
         break;
-      case "multi_select":
-        props[name] = { multi_select: {} };
+      }
+      case "multi_select": {
+        const options = normalizeSchemaOptions(name, entry.options);
+        props[name] = { multi_select: options ? { options } : {} };
         break;
+      }
+      case "status": {
+        const options = normalizeSchemaOptions(name, entry.options);
+        props[name] = { status: options ? { options } : {} };
+        break;
+      }
       case "date":
         props[name] = { date: {} };
         break;
@@ -177,11 +350,90 @@ export function schemaToProperties(schema: Array<{ name: string; type: string }>
       case "phone":
         props[name] = { phone_number: {} };
         break;
-      case "status":
-        props[name] = { status: {} };
+      case "formula":
+        if (typeof entry.expression !== "string" || entry.expression.trim().length === 0) {
+          throw new Error(`Property "${name}" is a formula and requires a non-empty expression.`);
+        }
+        props[name] = { formula: { expression: entry.expression } };
+        break;
+      case "rollup":
+        if (typeof entry.function !== "string" || entry.function.length === 0) {
+          throw new Error(`Property "${name}" is a rollup and requires a function.`);
+        }
+        if (typeof entry.relation_property !== "string" || entry.relation_property.length === 0) {
+          throw new Error(`Property "${name}" is a rollup and requires relation_property.`);
+        }
+        if (typeof entry.rollup_property !== "string" || entry.rollup_property.length === 0) {
+          throw new Error(`Property "${name}" is a rollup and requires rollup_property.`);
+        }
+        props[name] = {
+          rollup: {
+            function: entry.function,
+            relation_property_name: entry.relation_property,
+            rollup_property_name: entry.rollup_property,
+          },
+        };
+        break;
+      case "relation": {
+        if (typeof entry.data_source_id !== "string" || entry.data_source_id.length === 0) {
+          throw new Error(`Property "${name}" is a relation and requires data_source_id.`);
+        }
+        const relationType =
+          entry.relation_type === "dual_property" ? "dual_property" : "single_property";
+        props[name] = relationType === "dual_property"
+          ? {
+              relation: {
+                data_source_id: entry.data_source_id,
+                type: "dual_property",
+                dual_property: entry.synced_property_name !== undefined
+                  ? { synced_property_name: entry.synced_property_name }
+                  : {},
+              },
+            }
+          : {
+              relation: {
+                data_source_id: entry.data_source_id,
+                type: "single_property",
+                single_property: {},
+              },
+            };
+        break;
+      }
+      case "unique_id":
+        props[name] = { unique_id: entry.prefix !== undefined ? { prefix: entry.prefix } : {} };
+        break;
+      case "people":
+        props[name] = { people: {} };
+        break;
+      case "files":
+        props[name] = { files: {} };
+        break;
+      case "verification":
+        props[name] = { verification: {} };
+        break;
+      case "place":
+        props[name] = { place: {} };
+        break;
+      case "location":
+        props[name] = { location: {} };
+        break;
+      case "button":
+        props[name] = { button: {} };
+        break;
+      case "created_time":
+        props[name] = { created_time: {} };
+        break;
+      case "last_edited_time":
+        props[name] = { last_edited_time: {} };
+        break;
+      case "created_by":
+        props[name] = { created_by: {} };
+        break;
+      case "last_edited_by":
+        props[name] = { last_edited_by: {} };
         break;
       default:
-        break;
+        throw invalidSchemaTypeError(name, type);
     }
   }
 
@@ -228,10 +480,16 @@ export function convertPropertyValue(
           .map((id) => ({ id: String(id) })),
       };
     case "people":
+      return {
+        people: (Array.isArray(value) ? value : [value])
+          .filter((id) => id)
+          .map((id) => ({ id: String(id) })),
+      };
     case "files":
       throw new Error(
         `Property '${key}' has type '${type}'. ` +
-          `easy-notion-mcp does not support writing '${type}' properties. ` +
+          `easy-notion-mcp does not support writing '${type}' properties yet. ` +
+          `Tracked task: notion-files-value-write. Only external URL writes are planned. ` +
           `Remove '${key}' from the payload, or set this field in the Notion UI.`,
       );
     case "formula":
@@ -241,11 +499,30 @@ export function convertPropertyValue(
     case "created_by":
     case "last_edited_by":
     case "unique_id":
-    case "verification":
       throw new Error(
         `Property '${key}' has type '${type}'. ` +
           `This type is computed by Notion and cannot be set via API. ` +
           `Remove '${key}' from the payload; Notion populates the value automatically.`,
+      );
+    case "verification":
+      throw new Error(
+        `Property '${key}' has type '${type}'. ` +
+          `easy-notion-mcp does not support writing '${type}' properties yet. ` +
+          `Tracked task: notion-verification-value-write. ` +
+          `Remove '${key}' from the payload, or set this field in the Notion UI.`,
+      );
+    case "place":
+    case "location":
+      throw new Error(
+        `Property '${key}' has type '${type}'. ` +
+          `This type is computed by Notion or not yet supported for writes. ` +
+          `Remove '${key}' from the payload for now.`,
+      );
+    case "button":
+      throw new Error(
+        `Property '${key}' has type '${type}'. ` +
+          `This type is trigger-only; buttons have no write value. ` +
+          `Remove '${key}' from the payload for now.`,
       );
     default:
       throw new Error(
@@ -504,13 +781,14 @@ export async function createDatabase(
   client: Client,
   parentId: string,
   title: string,
-  schema: Array<{ name: string; type: string }>,
+  schema: SchemaEntry[],
   options?: { is_inline?: boolean },
 ) {
+  const properties = await resolveRelationDataSourceIds(client, schema, schemaToProperties(schema));
   return client.databases.create({
     parent: { type: "page_id", page_id: parentId },
     title: titleRichText(title),
-    initial_data_source: { properties: schemaToProperties(schema) },
+    initial_data_source: { properties },
     ...(options?.is_inline !== undefined ? { is_inline: options.is_inline } : {}),
   } as any);
 }
@@ -538,7 +816,19 @@ export async function updateDataSource(
 
   const body: Record<string, unknown> = { data_source_id: dataSourceId };
   if (updates.title !== undefined) body.title = titleRichText(updates.title);
-  if (updates.properties !== undefined) body.properties = updates.properties;
+  if (updates.properties !== undefined) {
+    const rawProperties = updates.properties as Record<string, unknown>;
+    const schemaEntries = Object.entries(rawProperties).map(([name, value]) => (
+      { name, ...(value as Record<string, unknown>) }
+    )) as SchemaEntry[];
+    body.properties = isSchemaShapePropertiesMap(rawProperties)
+      ? await resolveRelationDataSourceIds(
+          client,
+          schemaEntries,
+          schemaToProperties(schemaEntries),
+        )
+      : updates.properties;
+  }
   if (updates.in_trash !== undefined) body.in_trash = updates.in_trash;
 
   const result = await client.dataSources.update(body as any);

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,7 @@ import {
   updateDatabaseEntry,
   updatePage,
   type PageParent,
+  type SchemaEntry,
 } from "./notion-client.js";
 import type { NotionBlock, RichText } from "./types.js";
 
@@ -74,6 +75,41 @@ export function simplifyProperty(prop: any): unknown {
       return prop.phone_number;
     case "status":
       return prop.status?.name ?? null;
+    case "formula":
+      if (!prop.formula) return null;
+      switch (prop.formula.type) {
+        case "number":
+          return prop.formula.number ?? null;
+        case "string":
+          return prop.formula.string ?? null;
+        case "boolean":
+          return prop.formula.boolean ?? null;
+        case "date":
+          return prop.formula.date ?? null;
+        default:
+          return null;
+      }
+    case "rollup":
+      if (!prop.rollup) return null;
+      switch (prop.rollup.type) {
+        case "number":
+          return prop.rollup.number ?? null;
+        case "date":
+          return prop.rollup.date ?? null;
+        case "array":
+          return prop.rollup.array?.map((item: any) => simplifyProperty(item)) ?? [];
+        case "unsupported":
+        case "incomplete":
+          return null;
+        default:
+          return null;
+      }
+    case "files":
+      return prop.files?.map((file: any) => ({
+        type: file.type,
+        url: file.type === "external" ? file.external?.url : file.file?.url,
+        name: file.name,
+      })) ?? [];
     case "people":
       return prop.people?.map((p: any) => p.name ?? p.id) ?? [];
     case "relation":
@@ -83,6 +119,24 @@ export function simplifyProperty(prop: any): unknown {
       return prop.unique_id.prefix
         ? `${prop.unique_id.prefix}-${prop.unique_id.number}`
         : String(prop.unique_id.number);
+    case "created_time":
+      return prop.created_time ?? null;
+    case "last_edited_time":
+      return prop.last_edited_time ?? null;
+    case "created_by":
+      return prop.created_by?.name ?? prop.created_by?.id ?? null;
+    case "last_edited_by":
+      return prop.last_edited_by?.name ?? prop.last_edited_by?.id ?? null;
+    case "verification":
+      return {
+        state: prop.verification?.state ?? "unverified",
+        verified_by: prop.verification?.verified_by?.name ?? prop.verification?.verified_by?.id ?? null,
+        date: prop.verification?.date ?? null,
+      };
+    case "place":
+      return prop.place ?? null;
+    case "button":
+      return null;
     default:
       return null;
   }
@@ -682,7 +736,23 @@ Update a section of a page by heading name. Finds the heading, replaces everythi
   },
   {
     name: "create_database",
-    description: "Create a database under a parent page. Supported property types: title, text, number, select, multi_select, date, checkbox, url, email, phone, status.",
+    description: `Create a database under a parent page.
+
+Supported property types and extras:
+- title
+- rich_text (alias: text)
+- number (optional: format, for example "dollar", "percent", "number_with_commas")
+- select, multi_select, status (optional: options array of strings or {name, color, description})
+- date, checkbox, url, email, phone
+- formula (required: expression, for example "prop(\\"Count\\") * 2")
+- rollup (required: function, relation_property, rollup_property)
+- relation (required: data_source_id; optional: relation_type "single_property" or "dual_property", synced_property_name)
+- unique_id (optional: prefix, for example "ENG")
+- people, files
+- created_time, last_edited_time, created_by, last_edited_by
+- verification, place, location, button
+
+Unknown property types fail with an explicit error. No silent drops.`,
     inputSchema: {
       type: "object",
       properties: {
@@ -707,27 +777,31 @@ Update a section of a page by heading name. Finds the heading, replaces everythi
   },
   {
     name: "update_data_source",
-    description: `CRITICAL — full-list semantics: when you update a select or status property's \`options\` array, you MUST send the FULL desired list. ANY existing option you omit will be permanently removed from the database, along with any relationship to rows currently using it. Rows that currently reference a removed option are SILENTLY REASSIGNED to the default group's first option (e.g. 'Not started' for status properties) — not cleared, not errored, not left dangling. NO SIGNAL IS RAISED. If you want to preserve the meaning of existing rows when removing an option, reclassify those rows to another explicit option BEFORE removing the option from the schema. To ADD one option, first call get_database, then resend the full current list with your addition appended.
+    description: `CRITICAL: full-list semantics. When you update a select or status property's \`options\` array, you MUST send the full desired list. Any existing option you omit will be permanently removed from the database, along with any relationship to rows currently using it. Rows that currently reference a removed option are silently reassigned to the default group's first option (for example "Not started" for status properties). No signal is raised. If you want to preserve the meaning of existing rows when removing an option, reclassify those rows to another explicit option before removing the option from the schema. To add one option, first call get_database, then resend the full current list with your addition appended.
 
-Cannot toggle \`is_inline\` on existing databases — \`is_inline\` is a database-level field, not a data-source field. A separate \`update_database\` tool will be added in a future PR.
+Cannot toggle \`is_inline\` on existing databases. \`is_inline\` is a database-level field, not a data-source field. A separate \`update_database\` tool may be added later.
 
-Updates a database's schema: rename existing properties, add/update/remove select or status options, change the database title, or move it to/from trash. Use this AFTER get_database tells you the current schema. Pass the same \`database_id\` you passed to get_database — the server resolves the underlying data source internally.
+Updates a database's schema: rename existing properties, add or update many property types, remove properties, change the database title, or move it to or from trash. Use this after get_database tells you the current schema. Pass the same \`database_id\` you passed to get_database. The server resolves the underlying data source internally.
 
-The \`properties\` field uses the raw Notion API shape. The server does NO merging, normalization, or validation of property payloads — whatever you send is forwarded as-is. In particular: sending \`null\` as a property value permanently DELETES that property (and any row data in it).
+The \`properties\` field supports two modes:
+- Raw Notion API shape: the server forwards your payload as-is. This preserves advanced and back-compat flows such as rename payloads, raw formula objects, and deletes via \`null\`.
+- Schema helper shape: if every property entry has a top-level \`type\` plus helper fields and none of the raw Notion keys, the server validates and converts it for you. Example: { "Score": { "type": "formula", "expression": "1+1" } }.
+
+The routing rule is all-or-nothing per call. If any property entry looks raw, the whole payload is treated as raw pass-through.
 
 Status property notes:
-- As of Notion's 2026-03-19 changelog, status properties are updatable via API (https://developers.notion.com/page/changelog). The legacy \`update-a-database\` and \`update-property-schema-object\` reference pages still claim status is non-updatable — ignore those; the changelog is authoritative.
-- Status property GROUPS (default: "To-do" / "In progress" / "Complete") CANNOT be reconfigured via API. Group structure must be edited in the Notion UI. New status options added via API are assigned to the default group and cannot be reassigned programmatically.
+- As of Notion's 2026-03-19 changelog, status properties are updatable via API (https://developers.notion.com/page/changelog). The legacy \`update-a-database\` and \`update-property-schema-object\` reference pages still say otherwise. The changelog is authoritative.
+- Status property groups (default: "To-do" / "In progress" / "Complete") cannot be reconfigured via API. Group structure must be edited in the Notion UI. New status options added via API are assigned to the default group and cannot be reassigned programmatically.
 - Known upstream issue: Notion's API may return a stale schema where options assigned to the \`in_progress\` group appear as an empty array, causing validation errors on writes (makenotion/notion-mcp-server#232). If writes to in_progress-group options fail unexpectedly, this is the likely cause.
 
 Property payload examples (raw Notion shape):
-- Rename a property:         { "Old Name": { "name": "New Name" } }
-- Replace status options:    { "Status": { "status": { "options": [{ "name": "Backlog" }, { "name": "Doing" }, { "name": "Done" }] } } }
+- Rename a property: { "Old Name": { "name": "New Name" } }
+- Replace status options: { "Status": { "status": { "options": [{ "name": "Backlog" }, { "name": "Doing" }, { "name": "Done" }] } } }
 - Permanently delete a property and its data: { "Unused": null }
 
-This tool CANNOT update row/page data — use page update tools for that.
+This tool cannot update row or page data. Use page update tools for that.
 
-At least one of \`title\`, \`properties\`, or \`in_trash\` must be provided; empty updates are rejected.`,
+At least one of \`title\`, \`properties\`, or \`in_trash\` must be provided. Empty updates are rejected.`,
     inputSchema: {
       type: "object",
       properties: {
@@ -787,7 +861,25 @@ Call get_database first to see available properties and valid options.`,
   },
   {
     name: "add_database_entry",
-    description: `Create a new entry in a database. Pass properties as simple key-value pairs \u2014 the server converts using the database schema. Example: { "Name": "Buy groceries", "Status": "Todo", "Priority": "High", "Due": "2025-03-20", "Tags": ["Personal"] }. Call get_database to see available property names and valid select/status options.`,
+    description: `Create a new entry in a database.
+
+Writable property values use simple inputs:
+- title, rich_text: string
+- number: number
+- select, status: option name string
+- multi_select: array of option name strings
+- date: ISO date string (start only)
+- checkbox: boolean
+- url, email, phone: string
+- relation: string or array of page IDs
+- people: string or array of user IDs
+
+Not writable from this tool:
+- formula, rollup, unique_id, created_time, last_edited_time, created_by, last_edited_by: computed by Notion
+- files, verification, place, location, button: not supported for value writes here
+
+Example: { "Name": "Buy groceries", "Status": "Todo", "Priority": "High", "Due": "2025-03-20", "Tags": ["Personal"] }.
+Call get_database to see available property names and valid select or status options.`,
     inputSchema: {
       type: "object",
       properties: {
@@ -818,7 +910,24 @@ Call get_database first to see available properties and valid options.`,
   },
   {
     name: "update_database_entry",
-    description: "Update an existing database entry. Pass only the properties you want to change \u2014 omitted properties are left unchanged. Uses the same simple key-value format as add_database_entry. Call get_database to see valid property names and options.",
+    description: `Update an existing database entry. Pass only the properties you want to change; omitted properties are left unchanged.
+
+Writable property values use the same simple inputs as add_database_entry:
+- title, rich_text: string
+- number: number
+- select, status: option name string
+- multi_select: array of option name strings
+- date: ISO date string (start only)
+- checkbox: boolean
+- url, email, phone: string
+- relation: string or array of page IDs
+- people: string or array of user IDs
+
+Not writable from this tool:
+- formula, rollup, unique_id, created_time, last_edited_time, created_by, last_edited_by: computed by Notion
+- files, verification, place, location, button: not supported for value writes here
+
+Call get_database to see valid property names and options.`,
     inputSchema: {
       type: "object",
       properties: {
@@ -1296,7 +1405,7 @@ export function createServer(
           const { title, parent_page_id, schema, is_inline } = args as {
             title: string;
             parent_page_id: string;
-            schema: Array<{ name: string; type: string }>;
+            schema: SchemaEntry[];
             is_inline?: boolean;
           };
           const result = await createDatabase(

--- a/tests/convert-property-value.test.ts
+++ b/tests/convert-property-value.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { convertPropertyValue } from "../src/notion-client.js";
+
+describe("convertPropertyValue", () => {
+  it("converts a single people ID", () => {
+    expect(convertPropertyValue("people", "Owner", "user-1")).toEqual({
+      people: [{ id: "user-1" }],
+    });
+  });
+
+  it("converts multiple people IDs", () => {
+    expect(convertPropertyValue("people", "Owner", ["user-1", "user-2"])).toEqual({
+      people: [{ id: "user-1" }, { id: "user-2" }],
+    });
+  });
+
+  it("throws for files with the deferred task pointer", () => {
+    expect(() => convertPropertyValue("files", "Attachments", "https://example.com/file.pdf")).toThrow(
+      /files|notion-files-value-write/i,
+    );
+  });
+
+  it("throws for verification with the deferred task pointer", () => {
+    expect(() => convertPropertyValue("verification", "Verified", true)).toThrow(
+      /verification|notion-verification-value-write/i,
+    );
+  });
+
+  it("throws for place and button with a type-specific message", () => {
+    expect(() => convertPropertyValue("place", "Geo", { lat: 1.2, lon: 3.4 })).toThrow(/place/i);
+    expect(() => convertPropertyValue("button", "Run", "click")).toThrow(/button/i);
+  });
+
+  it("throws for computed Notion types", () => {
+    for (const type of [
+      "formula",
+      "rollup",
+      "unique_id",
+      "created_time",
+      "last_edited_time",
+      "created_by",
+      "last_edited_by",
+    ]) {
+      expect(() => convertPropertyValue(type, "Computed", "value")).toThrow(/computed by Notion/i);
+    }
+  });
+});

--- a/tests/create-database-response.test.ts
+++ b/tests/create-database-response.test.ts
@@ -43,12 +43,13 @@ async function connect(notion: any) {
 }
 
 describe("create_database response fidelity (G-4c)", () => {
-  it("G4c-1: response properties reflect Notion's actual result, not the requested schema (people silently dropped)", async () => {
+  it("G4c-1: people schema now succeeds and the response includes Owner", async () => {
     const createResult = {
       id: "db-1",
       url: "https://notion.so/db-1",
       properties: {
         Title: { id: "title", type: "title", title: {} },
+        Owner: { id: "owner", type: "people", people: {} },
       },
     };
     const notion = makeNotion(createResult);
@@ -66,8 +67,7 @@ describe("create_database response fidelity (G-4c)", () => {
         },
       });
       const response = JSON.parse(parseToolText(result));
-      expect(response.properties).toEqual(["Title"]);
-      expect(response.properties).not.toContain("Owner");
+      expect(response.properties.sort()).toEqual(["Owner", "Title"]);
     } finally {
       await close();
     }
@@ -105,7 +105,7 @@ describe("create_database response fidelity (G-4c)", () => {
     }
   });
 
-  it("G4c-3: requested schema with an unknown type — response omits it (reflects reality)", async () => {
+  it("G4c-3: unknown schema types fail validation before Notion is called", async () => {
     const createResult = {
       id: "db-3",
       url: "https://notion.so/db-3",
@@ -123,13 +123,13 @@ describe("create_database response fidelity (G-4c)", () => {
           parent_page_id: "parent-1",
           schema: [
             { name: "Title", type: "title" },
-            { name: "Wut", type: "nonexistent_type" },
+            { name: "Wut", type: "this_is_not_a_real_type" },
           ],
         },
       });
       const response = JSON.parse(parseToolText(result));
-      expect(response.properties).toEqual(["Title"]);
-      expect(response.properties).not.toContain("Wut");
+      expect(response.error).toMatch(/this_is_not_a_real_type|title|formula|relation|status/);
+      expect(notion.databases.create).not.toHaveBeenCalled();
     } finally {
       await close();
     }

--- a/tests/database-write-strictness.test.ts
+++ b/tests/database-write-strictness.test.ts
@@ -271,7 +271,7 @@ describe("Database write strictness — unsupported property types (G-4b)", () =
     }
   });
 
-  it("G4b-2: people property — 'does not support', NO future-release promise", async () => {
+  it("G4b-2: people property write succeeds", async () => {
     const dbId = freshDbId("b2");
     const notion = makeNotion({
       dbId,
@@ -283,12 +283,11 @@ describe("Database write strictness — unsupported property types (G-4b)", () =
         name: "add_database_entry",
         arguments: { database_id: dbId, properties: { Name: "x", Owner: "uid" } },
       });
-      const text = parseToolText(result);
-      expect(text).toContain("'Owner'");
-      expect(text).toContain("people");
-      expect(text).toMatch(/does not support/i);
-      expect(text).not.toMatch(/future release/i);
-      expect(notion.pages.create).not.toHaveBeenCalled();
+      const response = JSON.parse(parseToolText(result));
+      expect(response.id).toBe("created-page");
+      expect(notion.pages.create).toHaveBeenCalledTimes(1);
+      const callArgs = notion.pages.create.mock.calls[0][0];
+      expect(callArgs.properties.Owner).toEqual({ people: [{ id: "uid" }] });
     } finally {
       await close();
     }
@@ -367,8 +366,7 @@ describe("Database write strictness — unsupported property types (G-4b)", () =
     "created_by",
     "last_edited_by",
     "unique_id",
-    "verification",
-  ])("G4b-6: %s property — 'computed by Notion'", async (typeName) => {
+  ])("G4b-6: %s property is computed by Notion", async (typeName) => {
     const dbId = freshDbId(`b6-${typeName}`);
     const notion = makeNotion({
       dbId,
@@ -384,6 +382,28 @@ describe("Database write strictness — unsupported property types (G-4b)", () =
       expect(text).toContain("'Field'");
       expect(text).toContain(typeName);
       expect(text).toMatch(/computed by Notion/i);
+      expect(notion.pages.create).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+
+  it("G4b-6b: verification property points to the deferred write task", async () => {
+    const dbId = freshDbId("b6-verification");
+    const notion = makeNotion({
+      dbId,
+      schemaProvider: () => ({ Name: { type: "title" }, Field: { type: "verification" } }),
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const result = await client.callTool({
+        name: "add_database_entry",
+        arguments: { database_id: dbId, properties: { Name: "x", Field: "v" } },
+      });
+      const text = parseToolText(result);
+      expect(text).toContain("'Field'");
+      expect(text).toContain("verification");
+      expect(text).toContain("notion-verification-value-write");
       expect(notion.pages.create).not.toHaveBeenCalled();
     } finally {
       await close();
@@ -412,7 +432,7 @@ describe("Database write strictness — unsupported property types (G-4b)", () =
     }
   });
 
-  it("G4b-8: add_database_entries sandwich [good, bad(people), good] — loop continues after throw", async () => {
+  it("G4b-8: add_database_entries sandwich [good, people, good] succeeds for all three", async () => {
     const dbId = freshDbId("b8");
     const notion = makeNotion({
       dbId,
@@ -432,11 +452,8 @@ describe("Database write strictness — unsupported property types (G-4b)", () =
         },
       });
       const response = JSON.parse(parseToolText(result));
-      expect(response.succeeded).toHaveLength(2);
-      expect(response.failed).toHaveLength(1);
-      expect(response.failed[0].index).toBe(1);
-      expect(response.failed[0].error).toMatch(/people/);
-      expect(response.failed[0].error).toMatch(/does not support/i);
+      expect(response.succeeded).toHaveLength(3);
+      expect(response.failed).toHaveLength(0);
     } finally {
       await close();
     }

--- a/tests/e2e/live-mcp.test.ts
+++ b/tests/e2e/live-mcp.test.ts
@@ -67,6 +67,13 @@ type GetDatabaseResponse = {
     name: string;
     type: string;
     options?: string[];
+    expression?: string;
+    function?: string;
+    prefix?: string | null;
+    data_source_id?: string;
+    relation_type?: string;
+    relation_property?: string;
+    rollup_property?: string;
   }>;
   error?: string;
 };
@@ -378,14 +385,14 @@ describe.skipIf(!env.shouldRun)(
       expectContentNoticePresent(page.markdown);
     }, 20_000);
 
-    it("KNOWN GAP: create_database silently drops formula-type columns", async () => {
+    it("C1: create_database creates formula columns", async () => {
       const created = await callTool<CreateDatabaseResponse>(client, "create_database", {
         parent_page_id: ctx.sandboxId!,
-        title: "C1 formula drop",
+        title: "C1 formula create",
         schema: [
           { name: "Task", type: "title" },
           { name: "Count", type: "number" },
-          { name: "Score", type: "formula" },
+          { name: "Score", type: "formula", expression: 'prop("Count") * 2' },
         ],
       });
 
@@ -393,10 +400,9 @@ describe.skipIf(!env.shouldRun)(
       ctx.createdPageIds.push(created.id);
 
       expect(Array.isArray(created.properties)).toBe(true);
-      expect(created.properties).toEqual(["Task", "Count"]);
       expect(created.properties).toContain("Task");
       expect(created.properties).toContain("Count");
-      expect(created.properties).not.toContain("Score");
+      expect(created.properties).toContain("Score");
 
       const database = await callTool<GetDatabaseResponse>(client, "get_database", {
         database_id: created.id,
@@ -407,18 +413,42 @@ describe.skipIf(!env.shouldRun)(
         expect.arrayContaining([
           expect.objectContaining({ name: "Task", type: "title" }),
           expect.objectContaining({ name: "Count", type: "number" }),
+          expect.objectContaining({ name: "Score", type: "formula" }),
         ]),
       );
-      expect(database.properties).not.toEqual(
-        expect.arrayContaining([expect.objectContaining({ name: "Score" })]),
-      );
-      expect(database.properties.some((property) => property.type === "formula")).toBe(false);
-    }, 20_000);
 
-    it("KNOWN GAP: unsupported property types return null without warning", async () => {
+      const entry = await callTool<AddDatabaseEntryResponse>(client, "add_database_entry", {
+        database_id: created.id,
+        properties: {
+          Task: "row1",
+          Count: 5,
+        },
+      });
+
+      expect(entry.error).toBeUndefined();
+      ctx.createdPageIds.push(entry.id);
+
+      // Notion evaluates formulas asynchronously; poll a few times before asserting.
+      let row: Record<string, unknown> | undefined;
+      for (let attempt = 0; attempt < 6; attempt += 1) {
+        const rows = await callTool<Array<Record<string, unknown>>>(client, "query_database", {
+          database_id: created.id,
+        });
+        row = rows.find((candidate) => candidate.Task === "row1");
+        if (row && row.Score !== null && row.Score !== undefined) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2_000));
+      }
+
+      expect(row).toBeDefined();
+      expect(row?.Score).not.toBeNull();
+    }, 45_000);
+
+    it("C2: formula property values read back non-null", async () => {
       const created = await callTool<CreateDatabaseResponse>(client, "create_database", {
         parent_page_id: ctx.sandboxId!,
-        title: "C2 unsupported property null fallback",
+        title: "C2 formula read non-null",
         schema: [
           { name: "Title", type: "title" },
           { name: "Count", type: "number" },
@@ -463,16 +493,187 @@ describe.skipIf(!env.shouldRun)(
       expect(entry.error).toBeUndefined();
       ctx.createdPageIds.push(entry.id);
 
+      // Notion evaluates formulas asynchronously; poll a few times before asserting.
+      let rows: Array<Record<string, unknown>> = [];
+      let row: Record<string, unknown> | undefined;
+      for (let attempt = 0; attempt < 6; attempt += 1) {
+        rows = await callTool<Array<Record<string, unknown>>>(client, "query_database", {
+          database_id: created.id,
+        });
+        row = rows.find((candidate) => candidate.Title === "row1");
+        if (row && row.Formula !== null && row.Formula !== undefined) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2_000));
+      }
+
+      expect(Array.isArray(rows)).toBe(true);
+      expect(Object.prototype.hasOwnProperty.call(rows, "warnings")).toBe(false);
+      expect(row).toBeDefined();
+      expect(row).toEqual(expect.objectContaining({ Title: "row1", Count: 5 }));
+      expect(row?.Formula).not.toBeNull();
+    }, 45_000);
+
+    it("C3: relation schema create", async () => {
+      const source = await callTool<CreateDatabaseResponse>(client, "create_database", {
+        parent_page_id: ctx.sandboxId!,
+        title: "C3 relation source",
+        schema: [
+          { name: "Title", type: "title" },
+        ],
+      });
+      expect(source.error).toBeUndefined();
+      ctx.createdPageIds.push(source.id);
+
+      const created = await callTool<CreateDatabaseResponse>(client, "create_database", {
+        parent_page_id: ctx.sandboxId!,
+        title: "C3 relation target",
+        schema: [
+          { name: "Title", type: "title" },
+          { name: "Ref", type: "relation", data_source_id: source.id },
+        ],
+      });
+
+      expect(created.error).toBeUndefined();
+      ctx.createdPageIds.push(created.id);
+
+      const database = await callTool<GetDatabaseResponse>(client, "get_database", {
+        database_id: created.id,
+      });
+
+      expect(database.error).toBeUndefined();
+      expect(database.properties).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "Ref", type: "relation" }),
+        ]),
+      );
+    }, 30_000);
+
+    it("C4: rollup schema create", async () => {
+      const linked = await callTool<CreateDatabaseResponse>(client, "create_database", {
+        parent_page_id: ctx.sandboxId!,
+        title: "C4 rollup linked",
+        schema: [
+          { name: "Title", type: "title" },
+        ],
+      });
+      expect(linked.error).toBeUndefined();
+      ctx.createdPageIds.push(linked.id);
+
+      const created = await callTool<CreateDatabaseResponse>(client, "create_database", {
+        parent_page_id: ctx.sandboxId!,
+        title: "C4 rollup target",
+        schema: [
+          { name: "Title", type: "title" },
+          { name: "Ref", type: "relation", data_source_id: linked.id },
+          {
+            name: "RefCount",
+            type: "rollup",
+            function: "count",
+            relation_property: "Ref",
+            rollup_property: "Title",
+          },
+        ],
+      });
+
+      expect(created.error).toBeUndefined();
+      ctx.createdPageIds.push(created.id);
+
+      const database = await callTool<GetDatabaseResponse>(client, "get_database", {
+        database_id: created.id,
+      });
+
+      expect(database.error).toBeUndefined();
+      expect(database.properties).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "RefCount", type: "rollup", function: "count" }),
+        ]),
+      );
+    }, 30_000);
+
+    it("C5: people schema + value write", async () => {
+      const users = await callTool<Array<{ id: string; name?: string | null; type: string }>>(
+        client,
+        "list_users",
+        {},
+      );
+      const owner = users.find((candidate) => candidate.type === "bot" || candidate.type === "person");
+      expect(owner).toBeDefined();
+
+      const created = await callTool<CreateDatabaseResponse>(client, "create_database", {
+        parent_page_id: ctx.sandboxId!,
+        title: "C5 people",
+        schema: [
+          { name: "Title", type: "title" },
+          { name: "Owner", type: "people" },
+        ],
+      });
+
+      expect(created.error).toBeUndefined();
+      ctx.createdPageIds.push(created.id);
+
+      const entry = await callTool<AddDatabaseEntryResponse>(client, "add_database_entry", {
+        database_id: created.id,
+        properties: {
+          Title: "r1",
+          Owner: owner!.id,
+        },
+      });
+
+      expect(entry.error).toBeUndefined();
+      ctx.createdPageIds.push(entry.id);
+
       const rows = await callTool<Array<Record<string, unknown>>>(client, "query_database", {
         database_id: created.id,
       });
 
-      expect(Array.isArray(rows)).toBe(true);
-      expect(Object.prototype.hasOwnProperty.call(rows, "warnings")).toBe(false);
+      const row = rows.find((candidate) => candidate.Title === "r1");
+      expect(row).toBeDefined();
+      expect(Array.isArray(row?.Owner)).toBe(true);
+      expect((row?.Owner as unknown[]).length).toBeGreaterThan(0);
+    }, 30_000);
+
+    it("C6: unique_id schema with prefix", async () => {
+      const created = await callTool<CreateDatabaseResponse>(client, "create_database", {
+        parent_page_id: ctx.sandboxId!,
+        title: "C6 unique id",
+        schema: [
+          { name: "Title", type: "title" },
+          { name: "Ticket", type: "unique_id", prefix: "ENG" },
+        ],
+      });
+
+      expect(created.error).toBeUndefined();
+      ctx.createdPageIds.push(created.id);
+
+      const database = await callTool<GetDatabaseResponse>(client, "get_database", {
+        database_id: created.id,
+      });
+
+      expect(database.error).toBeUndefined();
+      expect(database.properties).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "Ticket", type: "unique_id", prefix: "ENG" }),
+        ]),
+      );
+
+      const entry = await callTool<AddDatabaseEntryResponse>(client, "add_database_entry", {
+        database_id: created.id,
+        properties: {
+          Title: "row1",
+        },
+      });
+
+      expect(entry.error).toBeUndefined();
+      ctx.createdPageIds.push(entry.id);
+
+      const rows = await callTool<Array<Record<string, unknown>>>(client, "query_database", {
+        database_id: created.id,
+      });
 
       const row = rows.find((candidate) => candidate.Title === "row1");
       expect(row).toBeDefined();
-      expect(row).toEqual(expect.objectContaining({ Title: "row1", Count: 5, Formula: null }));
+      expect(String(row?.Ticket)).toMatch(/^ENG-\d+$/);
     }, 30_000);
 
     it("E1: stdio file upload", async () => {

--- a/tests/property-roundtrip.test.ts
+++ b/tests/property-roundtrip.test.ts
@@ -1,0 +1,471 @@
+import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createServer } from "../src/server.js";
+
+function parseToolText(result: { content?: Array<{ type: string; text?: string }> }) {
+  const text = result.content?.find((item) => item.type === "text")?.text;
+  if (!text) throw new Error("expected text content");
+  return text;
+}
+
+function parseToolJson<T>(result: { content?: Array<{ type: string; text?: string }> }): T {
+  return JSON.parse(parseToolText(result)) as T;
+}
+
+type StoredSchema = Record<string, { type: string; [key: string]: unknown }>;
+
+function inferSchemaType(config: Record<string, unknown>) {
+  return (
+    (typeof config.type === "string" ? config.type : undefined) ??
+    Object.keys(config).find((key) => key !== "type" && key !== "description") ??
+    "unknown"
+  );
+}
+
+function hydrateSchema(properties: Record<string, Record<string, unknown>>): StoredSchema {
+  const out: StoredSchema = {};
+  for (const [name, config] of Object.entries(properties ?? {})) {
+    out[name] = { type: inferSchemaType(config), ...config };
+  }
+  return out;
+}
+
+function decorateWithTypes(
+  properties: Record<string, any>,
+  schema: StoredSchema,
+): Record<string, any> {
+  const out: Record<string, any> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    const type = schema[key]?.type ?? "rich_text";
+    out[key] = { type, ...value };
+  }
+  return out;
+}
+
+let counter = 0;
+const freshDbId = (tag: string) => `db-prop-rt-${tag}-${++counter}`;
+
+function makeStatefulNotion(dbId: string) {
+  const dsId = `ds-for-${dbId}`;
+  const pageStore = new Map<string, any>();
+  let title = "Untitled";
+  let schema: StoredSchema = {};
+
+  const notion = {
+    databases: {
+      retrieve: vi.fn(async ({ database_id }: any) => ({
+        id: database_id,
+        title: [{ plain_text: title }],
+        url: `https://notion.so/${database_id}`,
+        data_sources: [{ id: dsId }],
+      })),
+      create: vi.fn(async (body: any) => {
+        title = body.title?.[0]?.text?.content ?? title;
+        schema = hydrateSchema(body.initial_data_source?.properties ?? {});
+        return {
+          id: dbId,
+          url: `https://notion.so/${dbId}`,
+        };
+      }),
+    },
+    dataSources: {
+      retrieve: vi.fn(async ({ data_source_id }: any) => ({
+        id: data_source_id,
+        properties: schema,
+      })),
+      query: vi.fn(async () => ({ results: Array.from(pageStore.values()) })),
+      update: vi.fn(),
+    },
+    pages: {
+      retrieve: vi.fn(async ({ page_id }: any) => {
+        const stored = pageStore.get(page_id);
+        if (stored) return stored;
+        return {
+          id: page_id,
+          parent: { type: "database_id", database_id: dbId },
+        };
+      }),
+      create: vi.fn(async ({ properties }: any) => {
+        const id = `page-${pageStore.size + 1}`;
+        const stored = {
+          id,
+          url: `https://notion.so/${id}`,
+          parent: { type: "data_source_id", database_id: dbId },
+          properties: decorateWithTypes(properties, schema),
+        };
+        pageStore.set(id, stored);
+        return stored;
+      }),
+      update: vi.fn(async ({ page_id, properties }: any) => {
+        const existing = pageStore.get(page_id);
+        if (!existing) {
+          throw new Error(`update on non-existent page ${page_id}`);
+        }
+        const merged = {
+          ...existing,
+          properties: {
+            ...existing.properties,
+            ...decorateWithTypes(properties, schema),
+          },
+        };
+        pageStore.set(page_id, merged);
+        return merged;
+      }),
+    },
+    blocks: { children: { list: vi.fn(), append: vi.fn() }, delete: vi.fn() },
+    users: { list: vi.fn(), me: vi.fn() },
+    search: vi.fn(),
+    comments: { list: vi.fn(), create: vi.fn() },
+    fileUploads: { create: vi.fn(), send: vi.fn() },
+  };
+
+  return { notion, pageStore };
+}
+
+async function connect(notion: any) {
+  const server = createServer(() => notion, {});
+  const client = new McpClient(
+    { name: "property-roundtrip-test", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  const [a, b] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(b), client.connect(a)]);
+  return {
+    client,
+    async close() {
+      await Promise.all([a.close(), b.close()]);
+    },
+  };
+}
+
+describe("property schema roundtrip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("round-trips a formula schema", async () => {
+    const dbId = freshDbId("formula");
+    const { notion } = makeStatefulNotion(dbId);
+    const { client, close } = await connect(notion);
+    try {
+      const createResult = await client.callTool({
+        name: "create_database",
+        arguments: {
+          title: "Formula DB",
+          parent_page_id: "parent-1",
+          schema: [
+            { name: "Task", type: "title" },
+            { name: "Score", type: "formula", expression: 'prop("Count") * 2' },
+          ],
+        },
+      });
+      const created = parseToolJson<{ id: string }>(createResult);
+      const createCall = notion.databases.create.mock.calls[0][0];
+      expect(createCall.initial_data_source.properties.Score).toEqual({
+        formula: { expression: 'prop("Count") * 2' },
+      });
+
+      const database = parseToolJson<{ properties: Array<{ name: string; type: string }> }>(
+        await client.callTool({ name: "get_database", arguments: { database_id: created.id } }),
+      );
+      expect(database.properties).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: "Score", type: "formula" })]),
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("round-trips a rollup schema", async () => {
+    const dbId = freshDbId("rollup");
+    const { notion } = makeStatefulNotion(dbId);
+    const { client, close } = await connect(notion);
+    try {
+      const createResult = await client.callTool({
+        name: "create_database",
+        arguments: {
+          title: "Rollup DB",
+          parent_page_id: "parent-1",
+          schema: [
+            { name: "Task", type: "title" },
+            {
+              name: "TotalHours",
+              type: "rollup",
+              function: "sum",
+              relation_property: "Tasks",
+              rollup_property: "Hours",
+            },
+          ],
+        },
+      });
+      const created = parseToolJson<{ id: string }>(createResult);
+      const createCall = notion.databases.create.mock.calls[0][0];
+      expect(createCall.initial_data_source.properties.TotalHours).toEqual({
+        rollup: {
+          function: "sum",
+          relation_property_name: "Tasks",
+          rollup_property_name: "Hours",
+        },
+      });
+
+      const database = parseToolJson<{ properties: Array<{ name: string; type: string }> }>(
+        await client.callTool({ name: "get_database", arguments: { database_id: created.id } }),
+      );
+      expect(database.properties).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: "TotalHours", type: "rollup" })]),
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("round-trips relation schemas for single_property and dual_property", async () => {
+    const dbId = freshDbId("relation");
+    const { notion } = makeStatefulNotion(dbId);
+    const { client, close } = await connect(notion);
+    try {
+      const createResult = await client.callTool({
+        name: "create_database",
+        arguments: {
+          title: "Relation DB",
+          parent_page_id: "parent-1",
+          schema: [
+            { name: "Task", type: "title" },
+            { name: "Links", type: "relation", data_source_id: "ds-target" },
+            {
+              name: "Mirror",
+              type: "relation",
+              data_source_id: "ds-target",
+              relation_type: "dual_property",
+              synced_property_name: "Source",
+            },
+          ],
+        },
+      });
+      const created = parseToolJson<{ id: string }>(createResult);
+      const createCall = notion.databases.create.mock.calls[0][0];
+      expect(createCall.initial_data_source.properties.Links).toEqual({
+        relation: {
+          data_source_id: `ds-for-${dbId}`,
+          type: "single_property",
+          single_property: {},
+        },
+      });
+      expect(createCall.initial_data_source.properties.Mirror).toEqual({
+        relation: {
+          data_source_id: `ds-for-${dbId}`,
+          type: "dual_property",
+          dual_property: { synced_property_name: "Source" },
+        },
+      });
+
+      const database = parseToolJson<{ properties: Array<{ name: string; type: string }> }>(
+        await client.callTool({ name: "get_database", arguments: { database_id: created.id } }),
+      );
+      expect(database.properties).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "Links", type: "relation" }),
+          expect.objectContaining({ name: "Mirror", type: "relation" }),
+        ]),
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("round-trips unique_id schemas with and without prefix", async () => {
+    const dbId = freshDbId("unique");
+    const { notion } = makeStatefulNotion(dbId);
+    const { client, close } = await connect(notion);
+    try {
+      const createResult = await client.callTool({
+        name: "create_database",
+        arguments: {
+          title: "Unique DB",
+          parent_page_id: "parent-1",
+          schema: [
+            { name: "Task", type: "title" },
+            { name: "Ticket", type: "unique_id", prefix: "ENG" },
+            { name: "Counter", type: "unique_id" },
+          ],
+        },
+      });
+      const created = parseToolJson<{ id: string }>(createResult);
+      const createCall = notion.databases.create.mock.calls[0][0];
+      expect(createCall.initial_data_source.properties.Ticket).toEqual({
+        unique_id: { prefix: "ENG" },
+      });
+      expect(createCall.initial_data_source.properties.Counter).toEqual({
+        unique_id: {},
+      });
+
+      const database = parseToolJson<{ properties: Array<{ name: string; type: string }> }>(
+        await client.callTool({ name: "get_database", arguments: { database_id: created.id } }),
+      );
+      expect(database.properties).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "Ticket", type: "unique_id" }),
+          expect.objectContaining({ name: "Counter", type: "unique_id" }),
+        ]),
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("round-trips people schema and values through add_database_entry and query_database", async () => {
+    const dbId = freshDbId("people");
+    const { notion } = makeStatefulNotion(dbId);
+    const { client, close } = await connect(notion);
+    try {
+      const createResult = await client.callTool({
+        name: "create_database",
+        arguments: {
+          title: "People DB",
+          parent_page_id: "parent-1",
+          schema: [
+            { name: "Task", type: "title" },
+            { name: "Owner", type: "people" },
+          ],
+        },
+      });
+      const created = parseToolJson<{ id: string }>(createResult);
+
+      const addResult = parseToolJson<{ id?: string; error?: string }>(
+        await client.callTool({
+          name: "add_database_entry",
+          arguments: {
+            database_id: created.id,
+            properties: { Task: "row1", Owner: "user-1" },
+          },
+        }),
+      );
+      expect(addResult.error).toBeUndefined();
+
+      const createCall = notion.pages.create.mock.calls[0][0];
+      expect(createCall.properties.Owner).toEqual({ people: [{ id: "user-1" }] });
+
+      const rows = parseToolJson<Array<Record<string, unknown>>>(
+        await client.callTool({ name: "query_database", arguments: { database_id: created.id } }),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toEqual(expect.objectContaining({ Owner: ["user-1"] }));
+    } finally {
+      await close();
+    }
+  });
+
+  it("round-trips files and verification schemas", async () => {
+    const dbId = freshDbId("schema-only");
+    const { notion } = makeStatefulNotion(dbId);
+    const { client, close } = await connect(notion);
+    try {
+      const createResult = await client.callTool({
+        name: "create_database",
+        arguments: {
+          title: "Schema Only DB",
+          parent_page_id: "parent-1",
+          schema: [
+            { name: "Task", type: "title" },
+            { name: "Attachments", type: "files" },
+            { name: "Verified", type: "verification" },
+          ],
+        },
+      });
+      const created = parseToolJson<{ id: string }>(createResult);
+      const createCall = notion.databases.create.mock.calls[0][0];
+      expect(createCall.initial_data_source.properties.Attachments).toEqual({ files: {} });
+      expect(createCall.initial_data_source.properties.Verified).toEqual({ verification: {} });
+
+      const database = parseToolJson<{ properties: Array<{ name: string; type: string }> }>(
+        await client.callTool({ name: "get_database", arguments: { database_id: created.id } }),
+      );
+      expect(database.properties).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "Attachments", type: "files" }),
+          expect.objectContaining({ name: "Verified", type: "verification" }),
+        ]),
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("round-trips number format and select-like options", async () => {
+    const dbId = freshDbId("options");
+    const { notion } = makeStatefulNotion(dbId);
+    const { client, close } = await connect(notion);
+    try {
+      const createResult = await client.callTool({
+        name: "create_database",
+        arguments: {
+          title: "Options DB",
+          parent_page_id: "parent-1",
+          schema: [
+            { name: "Task", type: "title" },
+            { name: "Price", type: "number", format: "dollar" },
+            { name: "State", type: "select", options: ["Todo", "Done"] },
+            { name: "Tags", type: "multi_select", options: [{ name: "A", color: "blue" }] },
+            { name: "Status", type: "status", options: ["Todo", "Doing", "Done"] },
+          ],
+        },
+      });
+      const created = parseToolJson<{ id: string }>(createResult);
+      const createCall = notion.databases.create.mock.calls[0][0];
+      expect(createCall.initial_data_source.properties.Price).toEqual({
+        number: { format: "dollar" },
+      });
+      expect(createCall.initial_data_source.properties.State).toEqual({
+        select: { options: [{ name: "Todo" }, { name: "Done" }] },
+      });
+      expect(createCall.initial_data_source.properties.Tags).toEqual({
+        multi_select: { options: [{ name: "A", color: "blue" }] },
+      });
+      expect(createCall.initial_data_source.properties.Status).toEqual({
+        status: { options: [{ name: "Todo" }, { name: "Doing" }, { name: "Done" }] },
+      });
+
+      const database = parseToolJson<{ properties: Array<{ name: string; type: string; options?: string[] }> }>(
+        await client.callTool({ name: "get_database", arguments: { database_id: created.id } }),
+      );
+      expect(database.properties).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "Price", type: "number" }),
+          expect.objectContaining({ name: "State", type: "select", options: ["Todo", "Done"] }),
+          expect.objectContaining({ name: "Tags", type: "multi_select", options: ["A"] }),
+          expect.objectContaining({ name: "Status", type: "status", options: ["Todo", "Doing", "Done"] }),
+        ]),
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("rejects unknown schema types before any SDK call", async () => {
+    const dbId = freshDbId("unknown");
+    const { notion } = makeStatefulNotion(dbId);
+    const { client, close } = await connect(notion);
+    try {
+      const result = parseToolJson<{ error?: string }>(
+        await client.callTool({
+          name: "create_database",
+          arguments: {
+            title: "Unknown DB",
+            parent_page_id: "parent-1",
+            schema: [
+              { name: "Task", type: "title" },
+              { name: "Mystery", type: "this_is_not_a_real_type" },
+            ],
+          },
+        }),
+      );
+
+      expect(result.error).toMatch(/this_is_not_a_real_type|title|formula|relation/);
+      expect(notion.databases.create).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/schema-to-properties.test.ts
+++ b/tests/schema-to-properties.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+
+import { schemaToProperties } from "../src/notion-client.js";
+
+function asSchema<T extends Array<Record<string, unknown>>>(schema: T) {
+  return schema as Array<{ name: string; type: string }>;
+}
+
+describe("schemaToProperties", () => {
+  it("maps formula with expression", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          { name: "Score", type: "formula", expression: 'prop("Count") * 2' },
+        ]),
+      ),
+    ).toEqual({
+      Score: { formula: { expression: 'prop("Count") * 2' } },
+    });
+  });
+
+  it("throws when formula.expression is missing", () => {
+    expect(() =>
+      schemaToProperties(
+        asSchema([
+          { name: "Score", type: "formula" },
+        ]),
+      ),
+    ).toThrow(/Score/);
+  });
+
+  it("maps rollup with function and property names", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          {
+            name: "TotalHours",
+            type: "rollup",
+            function: "sum",
+            relation_property: "Tasks",
+            rollup_property: "Hours",
+          },
+        ]),
+      ),
+    ).toEqual({
+      TotalHours: {
+        rollup: {
+          function: "sum",
+          relation_property_name: "Tasks",
+          rollup_property_name: "Hours",
+        },
+      },
+    });
+  });
+
+  it("throws when rollup.function is missing", () => {
+    expect(() =>
+      schemaToProperties(
+        asSchema([
+          {
+            name: "TotalHours",
+            type: "rollup",
+            relation_property: "Tasks",
+            rollup_property: "Hours",
+          },
+        ]),
+      ),
+    ).toThrow(/TotalHours/);
+  });
+
+  it("throws when rollup.relation_property is missing", () => {
+    expect(() =>
+      schemaToProperties(
+        asSchema([
+          {
+            name: "TotalHours",
+            type: "rollup",
+            function: "sum",
+            rollup_property: "Hours",
+          },
+        ]),
+      ),
+    ).toThrow(/TotalHours/);
+  });
+
+  it("throws when rollup.rollup_property is missing", () => {
+    expect(() =>
+      schemaToProperties(
+        asSchema([
+          {
+            name: "TotalHours",
+            type: "rollup",
+            function: "sum",
+            relation_property: "Tasks",
+          },
+        ]),
+      ),
+    ).toThrow(/TotalHours/);
+  });
+
+  it("maps relation to single_property by default", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          { name: "Tasks", type: "relation", data_source_id: "ds-123" },
+        ]),
+      ),
+    ).toEqual({
+      Tasks: {
+        relation: {
+          data_source_id: "ds-123",
+          type: "single_property",
+          single_property: {},
+        },
+      },
+    });
+  });
+
+  it("maps relation to dual_property with synced_property_name", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          {
+            name: "Tasks",
+            type: "relation",
+            data_source_id: "ds-123",
+            relation_type: "dual_property",
+            synced_property_name: "Parent Project",
+          },
+        ]),
+      ),
+    ).toEqual({
+      Tasks: {
+        relation: {
+          data_source_id: "ds-123",
+          type: "dual_property",
+          dual_property: { synced_property_name: "Parent Project" },
+        },
+      },
+    });
+  });
+
+  it("throws when relation.data_source_id is missing", () => {
+    expect(() =>
+      schemaToProperties(
+        asSchema([
+          { name: "Tasks", type: "relation" },
+        ]),
+      ),
+    ).toThrow(/Tasks/);
+  });
+
+  it("maps unique_id with and without prefix", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          { name: "Ticket", type: "unique_id", prefix: "ENG" },
+          { name: "Auto", type: "unique_id" },
+        ]),
+      ),
+    ).toEqual({
+      Ticket: { unique_id: { prefix: "ENG" } },
+      Auto: { unique_id: {} },
+    });
+  });
+
+  it("maps number with and without format", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          { name: "Price", type: "number", format: "dollar" },
+          { name: "Count", type: "number" },
+        ]),
+      ),
+    ).toEqual({
+      Price: { number: { format: "dollar" } },
+      Count: { number: {} },
+    });
+  });
+
+  it("maps select, multi_select, and status string options", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          { name: "State", type: "select", options: ["Todo", "Done"] },
+          { name: "Tags", type: "multi_select", options: ["A", "B"] },
+          { name: "Status", type: "status", options: ["Todo", "Doing", "Done"] },
+        ]),
+      ),
+    ).toEqual({
+      State: { select: { options: [{ name: "Todo" }, { name: "Done" }] } },
+      Tags: { multi_select: { options: [{ name: "A" }, { name: "B" }] } },
+      Status: {
+        status: { options: [{ name: "Todo" }, { name: "Doing" }, { name: "Done" }] },
+      },
+    });
+  });
+
+  it("passes through structured options for select, multi_select, and status", () => {
+    const todo = { name: "Todo", color: "red", description: "Needs work" };
+    const doing = { name: "Doing", color: "blue", description: "Active" };
+
+    expect(
+      schemaToProperties(
+        asSchema([
+          { name: "State", type: "select", options: [todo] },
+          { name: "Tags", type: "multi_select", options: [doing] },
+          { name: "Status", type: "status", options: [todo, doing] },
+        ]),
+      ),
+    ).toEqual({
+      State: { select: { options: [todo] } },
+      Tags: { multi_select: { options: [doing] } },
+      Status: { status: { options: [todo, doing] } },
+    });
+  });
+
+  it("maps empty-object schema types", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          { name: "Owner", type: "people" },
+          { name: "Attachments", type: "files" },
+          { name: "Created", type: "created_time" },
+          { name: "Edited", type: "last_edited_time" },
+          { name: "Author", type: "created_by" },
+          { name: "Editor", type: "last_edited_by" },
+          { name: "Verified", type: "verification" },
+          { name: "Geo", type: "place" },
+          { name: "Action", type: "button" },
+          { name: "Where", type: "location" },
+        ]),
+      ),
+    ).toEqual({
+      Owner: { people: {} },
+      Attachments: { files: {} },
+      Created: { created_time: {} },
+      Edited: { last_edited_time: {} },
+      Author: { created_by: {} },
+      Editor: { last_edited_by: {} },
+      Verified: { verification: {} },
+      Geo: { place: {} },
+      Action: { button: {} },
+      Where: { location: {} },
+    });
+  });
+
+  it("maps text as rich_text", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          { name: "Notes", type: "text" },
+        ]),
+      ),
+    ).toEqual({
+      Notes: { rich_text: {} },
+    });
+  });
+
+  it("preserves existing simple types", () => {
+    expect(
+      schemaToProperties(
+        asSchema([
+          { name: "Title", type: "title" },
+          { name: "Due", type: "date" },
+          { name: "Done", type: "checkbox" },
+          { name: "Link", type: "url" },
+          { name: "Email", type: "email" },
+          { name: "Phone", type: "phone" },
+        ]),
+      ),
+    ).toEqual({
+      Title: { title: {} },
+      Due: { date: {} },
+      Done: { checkbox: {} },
+      Link: { url: {} },
+      Email: { email: {} },
+      Phone: { phone_number: {} },
+    });
+  });
+
+  it("throws on unknown property types with a valid-types list", () => {
+    expect(() =>
+      schemaToProperties(
+        asSchema([
+          { name: "Mystery", type: "this_is_not_a_real_type" },
+        ]),
+      ),
+    ).toThrow(/this_is_not_a_real_type|title|formula|relation|status/);
+  });
+});

--- a/tests/simplify-property.test.ts
+++ b/tests/simplify-property.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+
+import { simplifyProperty } from "../src/server.js";
+
+describe("simplifyProperty", () => {
+  it("simplifies formula number values", () => {
+    expect(
+      simplifyProperty({ type: "formula", formula: { type: "number", number: 42 } }),
+    ).toBe(42);
+  });
+
+  it("simplifies formula string values", () => {
+    expect(
+      simplifyProperty({ type: "formula", formula: { type: "string", string: "done" } }),
+    ).toBe("done");
+  });
+
+  it("simplifies formula boolean values", () => {
+    expect(
+      simplifyProperty({ type: "formula", formula: { type: "boolean", boolean: true } }),
+    ).toBe(true);
+  });
+
+  it("simplifies formula date values", () => {
+    expect(
+      simplifyProperty({
+        type: "formula",
+        formula: {
+          type: "date",
+          date: { start: "2026-04-21", end: null, time_zone: "America/Los_Angeles" },
+        },
+      }),
+    ).toEqual({
+      start: "2026-04-21",
+      end: null,
+      time_zone: "America/Los_Angeles",
+    });
+  });
+
+  it("simplifies rollup number values", () => {
+    expect(
+      simplifyProperty({ type: "rollup", rollup: { type: "number", number: 12, function: "sum" } }),
+    ).toBe(12);
+  });
+
+  it("simplifies rollup date values", () => {
+    expect(
+      simplifyProperty({
+        type: "rollup",
+        rollup: {
+          type: "date",
+          date: { start: "2026-04-21", end: null },
+          function: "latest_date",
+        },
+      }),
+    ).toEqual({ start: "2026-04-21", end: null });
+  });
+
+  it("simplifies rollup arrays recursively", () => {
+    expect(
+      simplifyProperty({
+        type: "rollup",
+        rollup: {
+          type: "array",
+          function: "show_original",
+          array: [
+            { type: "number", number: 2 },
+            { type: "select", select: { name: "Done" } },
+            { type: "place", place: { lat: 1.2, lon: 3.4, name: "HQ" } },
+          ],
+        },
+      }),
+    ).toEqual([2, "Done", { lat: 1.2, lon: 3.4, name: "HQ" }]);
+  });
+
+  it("returns null for unsupported and incomplete rollups", () => {
+    expect(
+      simplifyProperty({ type: "rollup", rollup: { type: "unsupported", unsupported: {}, function: "sum" } }),
+    ).toBeNull();
+    expect(
+      simplifyProperty({ type: "rollup", rollup: { type: "incomplete", incomplete: {}, function: "sum" } }),
+    ).toBeNull();
+  });
+
+  it("simplifies external files", () => {
+    expect(
+      simplifyProperty({
+        type: "files",
+        files: [
+          {
+            type: "external",
+            name: "Spec",
+            external: { url: "https://example.com/spec.pdf" },
+          },
+        ],
+      }),
+    ).toEqual([
+      { type: "external", url: "https://example.com/spec.pdf", name: "Spec" },
+    ]);
+  });
+
+  it("simplifies internal files", () => {
+    expect(
+      simplifyProperty({
+        type: "files",
+        files: [
+          {
+            type: "file",
+            name: "Internal",
+            file: { url: "https://files.notion.so/internal.pdf" },
+          },
+        ],
+      }),
+    ).toEqual([
+      { type: "file", url: "https://files.notion.so/internal.pdf", name: "Internal" },
+    ]);
+  });
+
+  it("simplifies mixed files", () => {
+    expect(
+      simplifyProperty({
+        type: "files",
+        files: [
+          {
+            type: "external",
+            name: "Spec",
+            external: { url: "https://example.com/spec.pdf" },
+          },
+          {
+            type: "file",
+            name: "Internal",
+            file: { url: "https://files.notion.so/internal.pdf" },
+          },
+        ],
+      }),
+    ).toEqual([
+      { type: "external", url: "https://example.com/spec.pdf", name: "Spec" },
+      { type: "file", url: "https://files.notion.so/internal.pdf", name: "Internal" },
+    ]);
+  });
+
+  it("preserves existing people behavior", () => {
+    expect(
+      simplifyProperty({
+        type: "people",
+        people: [{ name: "Ada", id: "user-1" }, { name: null, id: "user-2" }],
+      }),
+    ).toEqual(["Ada", "user-2"]);
+  });
+
+  it("simplifies unique_id with and without prefix, and null", () => {
+    expect(
+      simplifyProperty({ type: "unique_id", unique_id: { prefix: "ENG", number: 42 } }),
+    ).toBe("ENG-42");
+    expect(
+      simplifyProperty({ type: "unique_id", unique_id: { prefix: null, number: 42 } }),
+    ).toBe("42");
+    expect(
+      simplifyProperty({ type: "unique_id", unique_id: null }),
+    ).toBeNull();
+  });
+
+  it("passes through created_time and last_edited_time", () => {
+    expect(
+      simplifyProperty({ type: "created_time", created_time: "2026-04-21T12:00:00.000Z" }),
+    ).toBe("2026-04-21T12:00:00.000Z");
+    expect(
+      simplifyProperty({ type: "last_edited_time", last_edited_time: "2026-04-21T12:30:00.000Z" }),
+    ).toBe("2026-04-21T12:30:00.000Z");
+  });
+
+  it("simplifies created_by and last_edited_by with name fallback to id", () => {
+    expect(
+      simplifyProperty({ type: "created_by", created_by: { name: "Ada", id: "user-1" } }),
+    ).toBe("Ada");
+    expect(
+      simplifyProperty({ type: "last_edited_by", last_edited_by: { name: null, id: "user-2" } }),
+    ).toBe("user-2");
+  });
+
+  it("simplifies verification states", () => {
+    expect(
+      simplifyProperty({
+        type: "verification",
+        verification: {
+          state: "verified",
+          verified_by: { name: "Ada", id: "user-1" },
+          date: { start: "2026-04-21T12:00:00.000Z", end: null, time_zone: null },
+        },
+      }),
+    ).toEqual({
+      state: "verified",
+      verified_by: "Ada",
+      date: { start: "2026-04-21T12:00:00.000Z", end: null, time_zone: null },
+    });
+
+    expect(
+      simplifyProperty({
+        type: "verification",
+        verification: {
+          state: "expired",
+          verified_by: { name: null, id: "user-2" },
+          date: { start: "2026-04-20T12:00:00.000Z", end: null, time_zone: null },
+        },
+      }),
+    ).toEqual({
+      state: "expired",
+      verified_by: "user-2",
+      date: { start: "2026-04-20T12:00:00.000Z", end: null, time_zone: null },
+    });
+
+    expect(
+      simplifyProperty({
+        type: "verification",
+        verification: { state: "unverified", verified_by: null, date: null },
+      }),
+    ).toEqual({
+      state: "unverified",
+      verified_by: null,
+      date: null,
+    });
+  });
+
+  it("passes through place values and returns null when place is missing", () => {
+    expect(
+      simplifyProperty({
+        type: "place",
+        place: { lat: 1.2, lon: 3.4, name: "HQ", address: "1 Main St" },
+      }),
+    ).toEqual({ lat: 1.2, lon: 3.4, name: "HQ", address: "1 Main St" });
+    expect(
+      simplifyProperty({ type: "place", place: null }),
+    ).toBeNull();
+  });
+
+  it("returns null for location on the read path", () => {
+    expect(
+      simplifyProperty({
+        type: "location",
+        location: { lat: 1.2, lon: 3.4, name: "HQ" },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for button and unknown types", () => {
+    expect(
+      simplifyProperty({ type: "button", button: {} }),
+    ).toBeNull();
+    expect(
+      simplifyProperty({ type: "future_type", future_type: { enabled: true } }),
+    ).toBeNull();
+  });
+
+  it("preserves existing simple property behavior", () => {
+    expect(
+      simplifyProperty({
+        type: "title",
+        title: [{ plain_text: "Title" }, { plain_text: " Value" }],
+      }),
+    ).toBe("Title Value");
+    expect(
+      simplifyProperty({
+        type: "rich_text",
+        rich_text: [{ plain_text: "Hello" }, { plain_text: " world" }],
+      }),
+    ).toBe("Hello world");
+    expect(simplifyProperty({ type: "number", number: 5 })).toBe(5);
+    expect(simplifyProperty({ type: "select", select: { name: "Done" } })).toBe("Done");
+    expect(
+      simplifyProperty({ type: "multi_select", multi_select: [{ name: "A" }, { name: "B" }] }),
+    ).toEqual(["A", "B"]);
+    expect(
+      simplifyProperty({ type: "date", date: { start: "2026-04-21", end: null } }),
+    ).toBe("2026-04-21");
+    expect(simplifyProperty({ type: "checkbox", checkbox: true })).toBe(true);
+    expect(simplifyProperty({ type: "url", url: "https://example.com" })).toBe("https://example.com");
+    expect(simplifyProperty({ type: "email", email: "dev@example.com" })).toBe("dev@example.com");
+    expect(simplifyProperty({ type: "phone_number", phone_number: "555-0100" })).toBe("555-0100");
+    expect(simplifyProperty({ type: "status", status: { name: "Doing" } })).toBe("Doing");
+    expect(
+      simplifyProperty({ type: "relation", relation: [{ id: "page-1" }, { id: "page-2" }] }),
+    ).toEqual(["page-1", "page-2"]);
+  });
+});

--- a/tests/update-data-source.test.ts
+++ b/tests/update-data-source.test.ts
@@ -41,6 +41,89 @@ function getUpdateDataSource() {
 }
 
 describe("updateDataSource", () => {
+  it("routes schema-shape property payloads through the schema helper", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-schema-shape", data_sources: [{ id: "ds-schema-shape" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+
+    await getUpdateDataSource()(client as any, "db-schema-shape", {
+      properties: {
+        NewProp: { type: "formula", expression: "1+1" } as any,
+      } as any,
+    });
+
+    expect(client.dataSources.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data_source_id: "ds-schema-shape",
+        properties: {
+          NewProp: { formula: { expression: "1+1" } },
+        },
+      }),
+    );
+  });
+
+  it("passes raw formula payloads through unchanged", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-raw-formula", data_sources: [{ id: "ds-raw-formula" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+    const properties = {
+      Score: {
+        type: "formula",
+        formula: { expression: "1" },
+      },
+    };
+
+    await getUpdateDataSource()(client as any, "db-raw-formula", { properties: properties as any });
+
+    expect(client.dataSources.update.mock.calls[0]?.[0]?.properties).toBe(properties);
+  });
+
+  it("passes rename payloads through unchanged", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-rename-heuristic", data_sources: [{ id: "ds-rename-heuristic" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+    const properties = { Old: { name: "New" } };
+
+    await getUpdateDataSource()(client as any, "db-rename-heuristic", { properties: properties as any });
+
+    expect(client.dataSources.update.mock.calls[0]?.[0]?.properties).toBe(properties);
+  });
+
+  it("passes delete payloads through unchanged", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-delete-heuristic", data_sources: [{ id: "ds-delete-heuristic" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+    const properties = { Unused: null };
+
+    await getUpdateDataSource()(client as any, "db-delete-heuristic", { properties: properties as any });
+
+    expect(client.dataSources.update.mock.calls[0]?.[0]?.properties).toBe(properties);
+  });
+
+  it("treats mixed payloads as raw pass-through", async () => {
+    const client = makeMockClient({
+      databases: {
+        retrieve: vi.fn().mockResolvedValue({ id: "db-mixed-heuristic", data_sources: [{ id: "ds-mixed-heuristic" }] }),
+      } as Partial<MockClient["databases"]>,
+    });
+    const properties = {
+      New: { type: "formula", expression: 'prop("Count")' },
+      Rename: { name: "Renamed" },
+    };
+
+    await getUpdateDataSource()(client as any, "db-mixed-heuristic", { properties: properties as any });
+
+    expect(client.dataSources.update.mock.calls[0]?.[0]?.properties).toBe(properties);
+  });
+
   it("forwards a raw properties map unchanged", async () => {
     const client = makeMockClient({
       databases: {


### PR DESCRIPTION
## Summary

Closes the Notion property-type gap in easy-notion-mcp: every property type the Notion API (`2025-09-03`) exposes is now supported on the schema-create path, and read decoders cover every type returned under `query_database` and `read_page`. Unknown types fail loudly with a validation error (no more silent drops); `people` values are writable; `update_data_source` now accepts either the raw Notion shape or a simpler schema-helper shape and routes by inspection.

Plan: `.meta/plans/notion-property-type-gap-2026-04-21.md` (pre-reviewed by Codex; see §18). One PR per plan §8.

## What changed

**Schema creation (`schemaToProperties`).** Every Notion property type now maps to a valid SDK `PropertyConfigurationRequest`: `formula` (required `expression`), `rollup` (required `function` + `relation_property` + `rollup_property`), `relation` (single_property default, optional dual_property with `synced_property_name`; accepts database IDs and resolves via `getDataSourceId`), `unique_id` (optional `prefix`), `people`, `files`, `verification`, `place`, `location`, `button`, `created_time`, `last_edited_time`, `created_by`, `last_edited_by`, plus `number.format` and `select` / `multi_select` / `status` options.

**Read decode (`simplifyProperty`).** Polymorphic decoders for `formula` (number / string / boolean / date) and `rollup` (number / date / array with recursive decode / unsupported / incomplete). New decoders for `files`, `created_time`, `last_edited_time`, `created_by`, `last_edited_by`, `verification`, `place`, `button`.

**Value write (`convertPropertyValue`).** `people` is writable (string or array of user IDs). `files` / `verification` throw with pointers to their deferred tasks. `place` / `location` / `button` throw with explicit reasons. Computed types (`formula`, `rollup`, `unique_id`, `created_*`, `last_edited_*`) still throw.

**`update_data_source` routing heuristic.** If every property entry in the payload has a top-level `type` string from the supported set AND no reserved raw Notion keys, the server routes through the schema helper for validation and shape construction. Otherwise the raw pass-through is preserved. All-or-nothing per call: mixed payloads stay raw. The prior rename / delete-via-null / raw-formula patterns continue to work unchanged.

**`get_database` response.** Now surfaces per-type extras: `expression`, `function`, `relation_property`, `rollup_property`, `data_source_id`, `relation_type`, `prefix`, `format`.

**Tool descriptions.** Updated on `create_database`, `update_data_source`, `add_database_entry`, `update_database_entry` to document the new contract.

## Decisions (from plan §16; all defaults)

1. One PR, not split.
2. Defer `files` value write (backlog: `notion-files-value-write`).
3. Defer `verification` value write (backlog: `notion-verification-value-write`).
4. Include `relation_type: "dual_property"` support.
5. Accept both `data_source_id` and `database_id` for relations; resolve internally.
6. No client-side rollup function enum; pass through as string.
7. Extra-field names: `relation_property`, `rollup_property` (no `_name` suffix).
8. Schema path accepts both `place` and `location` as type strings; read path decodes `place` only (SDK does not expose `location` at read time).
9. Long tool descriptions retained as reference documentation for agents.

## Out of scope (tracked as backlog tasks)

Each was explicitly considered and deferred; please do NOT request these expansions in review.

- `notion-views-templates-emojis`: Views API, templates, custom emojis
- `notion-file-upload-modes`: multi_part and external_url upload modes
- `notion-block-type-coverage`: synced_block, child_database, link_to_page, meeting_notes, heading_4, tab
- `notion-database-level-update`: is_locked, is_inline, databases.update
- `notion-files-value-write`: writing `files` property values (external URL only path)
- `notion-verification-value-write`: writing verification state (wiki pages only)
- `notion-query-read-warnings`: structured warnings on null reads (requires query_database response shape change)
- `notion-formula-expression-lint`: client-side formula syntax validation
- `notion-multi-source-disambiguation`: `data_sources[0]` is the implicit target today
- `notion-schema-cache-type-drift`: 5-minute TTL stale type behavior
- `notion-last-visited-time-support`: undocumented on public docs, no page-value decode path
- `mcp-surface-notion-error-code`: preexisting, still backlog

## Version-neutral

Pinned to Notion-Version `2025-09-03`. This PR does not touch any of the three renamed fields (`after`, `archived`, `transcription`). When we migrate the version pin, none of this code changes.

## Test evidence

**Baseline (before):** 329 passing, 13 skipped, 0 failed across 26 files.
**After:** 402 passing, 13 skipped, 0 failed across 31 files. 73 net new tests (unit + e2e).

**TDD discipline (plan §9).** Failing tests first:

Phase 1 (tests-first): 42 failed / 343 passed / 6 failed files. Assertion mismatches, not compile errors. Paste:

```
FAIL  tests/simplify-property.test.ts > simplifyProperty > decodes verification
AssertionError: expected null to deeply equal { state: "verified", ... }
```

```
FAIL  tests/update-data-source.test.ts > updateDataSource > routes schema-shape property payloads through the schema helper
AssertionError: expected "vi.fn()" to be called with arguments
```

Phase 2 (implementation green): all 42 flipped, no regression on baseline 329.

**New unit test files:**
- `tests/schema-to-properties.test.ts` (per-type schema mapping + validation)
- `tests/simplify-property.test.ts` (per-type read decoders)
- `tests/convert-property-value.test.ts` (value writes, computed-type throws)
- `tests/property-roundtrip.test.ts` (end-to-end schema + value through the in-memory MCP)

**Modified unit tests:**
- `tests/create-database-response.test.ts`: G4c-1 (`people` now succeeds), G4c-3 (unknown type now throws)
- `tests/update-data-source.test.ts`: 5 new heuristic cases (schema-shape routed, raw pass-through preserved, mixed to raw, rename, null-delete)
- `tests/database-write-strictness.test.ts`: G4b-2 updated (people writes succeed), G4b-6 table split (verification has its own message pointing to backlog task), G4b-8 sandwich now 3/3 success

**Live e2e (`tests/e2e/live-mcp.test.ts`):**
- C1 `KNOWN GAP` flipped: `create_database` creates formula columns; the formula value reads back non-null after polling for Notion's async evaluation.
- C2 `KNOWN GAP` flipped: formula added via raw `update_data_source` path reads back non-null.
- C3: relation schema create (two linked databases).
- C4: rollup schema create (relation + rollup pointing at linked DB's title).
- C5: people schema + value write (list a user, assign them, read them back).
- C6: unique_id schema with `prefix: "ENG"` (read back as `ENG-1` on first row).

Both e2e passes ran back-to-back green (17 tests each run):
```
Test Files  4 passed (4)
     Tests  29 passed (29)
  Duration  46.37s
```
```
Test Files  4 passed (4)
     Tests  29 passed (29)
  Duration  49.70s
```

**Mutation hand-checks (plan §9.4):** swapping `formula` and `rollup` arms in `schemaToProperties` produced 4 failed / 21 passed in the targeted suite; swapping the cases in `simplifyProperty` produced 7 failed / 13 passed. Both reverts clean; source diff line count matched pre-mutation exactly.

**Full final run:**
```
Test Files  31 passed (31)
     Tests  402 passed (402)
```

## Files touched

```
src/notion-client.ts                    | 322 ++++++++++++++++++++++++++++++--
src/server.ts                           | 137 ++++++++++++--
tests/create-database-response.test.ts  |  14 +-
tests/database-write-strictness.test.ts |  47 +++--
tests/e2e/live-mcp.test.ts              | 231 +++++++++++++++++++++--
tests/update-data-source.test.ts        |  83 ++++++++
tests/convert-property-value.test.ts    |  NEW
tests/property-roundtrip.test.ts        |  NEW
tests/schema-to-properties.test.ts      |  NEW
tests/simplify-property.test.ts         |  NEW
```

## Notes for review

- The plan's §11 baseline claim of "1172 tests / 78 files" was inflated; the true baseline on `feat/property-type-gap` at build time is 329. The plan author's methodology for that number is unclear, but it does not change the engineering: every plan-specified test now exists and is green, and net count rose by 73.
- The e2e C1 and C2 probes poll for up to 12 seconds after row creation because Notion evaluates formulas asynchronously. Two back-to-back clean runs suggest the poll window is sufficient; if live tests flake in CI, bump the poll count or delay.
- `update_data_source`'s routing heuristic is documented in the tool description AND unit-tested (`update-data-source.test.ts` has five cases: schema-shape routed, raw formula preserved, rename raw, delete null raw, mixed to raw).
- `.env` was copied into the worktree locally to run live e2e; it is gitignored and not in this diff.

## Test plan

- [x] `npm run build` passes
- [x] `npm test -- --run` green, 402 passing / 13 skipped / 0 failed
- [x] `npm run test:e2e` green twice back-to-back (formula async-eval poll is stable)
- [x] Mutation hand-checks on formula/rollup arms force red then revert cleanly
- [x] Diff stat scoped to plan §3 to §5 files only
- [ ] Reviewer: verify `update_data_source` heuristic against your own raw payloads
- [ ] Reviewer: verify tool description wording is usable by downstream agents
- [ ] Reviewer: decide whether deferred backlog items need any note in docs/CHANGELOG

DO NOT MERGE without James's review.

Generated with [Claude Code](https://claude.com/claude-code)
