### PR TITLE
feat(pagination): long-property pagination + v0.5.0 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-23
+
+### Breaking changes
+
+- **`query_database` response shape changed from `Array<entry>` to
+  `{ results: Array<entry>, warnings?: Array<warning> }`.** The
+  `results` key is always present; `warnings` is included only when a
+  warning fires. Migration: change `rows` to `rows.results`. Existing
+  test call sites in the repo were migrated in the same change.
+
+### Added
+
+- **Long-property pagination for `query_database` and `read_page`.**
+  When Notion's `pages.retrieve` truncates multi-value properties at
+  25 items (`title`, `rich_text`, `relation`, `people`), the server
+  now calls `pages.properties.retrieve` to fetch up to
+  `max_property_items` (default 75, 0 means unlimited). When the cap
+  is hit, the response surfaces a `truncated_properties` warning with
+  a `how_to_fetch_all` hint pointing at the override.
+
+- **New input param `max_property_items` on both `query_database` and
+  `read_page`.** Negative values are rejected with a validation error
+  before any Notion API call.
+
+- **New warning code `truncated_properties`.** Detail shape:
+  `{ code, properties: [{ name, type, returned_count, cap }],
+  how_to_fetch_all }`.
+
+### Notes
+
+- **`read_page` paginates titles only.** Relation and people properties
+  on the page object are not paginated because `read_page` does not
+  surface them.
+
+- **Rollup-array pagination is deferred to a follow-up.** See the plan
+  at `.meta/plans/pr2-long-property-pagination-2026-04-23.md`,
+  section 2.2, for rationale.
+
 ## [0.4.0] - 2026-04-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-notion-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "mcpName": "io.github.misterwigglesworth/easy-notion",
   "description": "Token-efficient, markdown-first Notion MCP server — agents write markdown, never touch raw Notion JSON",
   "type": "module",

--- a/src/notion-client.ts
+++ b/src/notion-client.ts
@@ -38,6 +38,22 @@ function titleRichText(content: string) {
 }
 
 type PropertiesUpdate = UpdateDataSourceParameters["properties"];
+export type PaginatedPropertyType = "title" | "rich_text" | "relation" | "people";
+
+export type TruncatedPropertyEntry = {
+  name: string;
+  type: PaginatedPropertyType;
+  returned_count: number;
+  cap: number;
+};
+
+export type PaginationOpts = {
+  maxPropertyItems: number;
+  onlyTypes?: PaginatedPropertyType[];
+};
+
+const PROPERTY_PAGINATION_RUNAWAY_ERROR =
+  "paginatePropertyValue: runaway loop detected (no progress)";
 
 export type SchemaEntry = {
   name: string;
@@ -106,6 +122,123 @@ const RAW_PROPERTY_SHAPE_KEYS = new Set([
 const schemaCache = new Map<string, { schema: any; expires: number }>();
 const dataSourceIdCache = new Map<string, { dsId: string; expires: number }>();
 const SCHEMA_CACHE_TTL = 5 * 60 * 1000;
+
+function isPaginatedPropertyType(type: unknown): type is PaginatedPropertyType {
+  return type === "title" || type === "rich_text" || type === "relation" || type === "people";
+}
+
+function propertyItemValue(item: any, propertyType: PaginatedPropertyType): unknown {
+  switch (propertyType) {
+    case "title":
+      return item.title;
+    case "rich_text":
+      return item.rich_text;
+    case "relation":
+      return item.relation;
+    case "people":
+      return item.people;
+  }
+}
+
+export async function paginatePageProperties(
+  client: Client,
+  page: any,
+  opts: PaginationOpts,
+): Promise<{ page: any; warnings: TruncatedPropertyEntry[] }> {
+  if (!page?.properties) {
+    return { page, warnings: [] };
+  }
+
+  const properties = page.properties as Record<string, any>;
+  const nextProperties = { ...properties };
+  const warnings: TruncatedPropertyEntry[] = [];
+
+  for (const [name, prop] of Object.entries(properties)) {
+    const propertyType = prop?.type;
+    if (!isPaginatedPropertyType(propertyType)) {
+      continue;
+    }
+    if (opts.onlyTypes && !opts.onlyTypes.includes(propertyType)) {
+      continue;
+    }
+
+    const values = prop[propertyType];
+    if (!Array.isArray(values) || values.length !== 25) {
+      continue;
+    }
+
+    const paginated = await paginatePropertyValue(
+      client,
+      page.id,
+      prop.id,
+      propertyType,
+      opts.maxPropertyItems,
+    );
+
+    nextProperties[name] = { ...prop, [propertyType]: paginated.values };
+    if (paginated.truncatedAtCap) {
+      warnings.push({
+        name,
+        type: propertyType,
+        returned_count: paginated.values.length,
+        cap: opts.maxPropertyItems,
+      });
+    }
+  }
+
+  return { page: { ...page, properties: nextProperties }, warnings };
+}
+
+async function paginatePropertyValue(
+  client: Client,
+  pageId: string,
+  propertyId: string,
+  propertyType: PaginatedPropertyType,
+  cap: number,
+): Promise<{ values: unknown[]; truncatedAtCap: boolean }> {
+  const values: unknown[] = [];
+  let cursor: string | undefined;
+
+  while (true) {
+    const request: { page_id: string; property_id: string; start_cursor?: string } = {
+      page_id: pageId,
+      property_id: propertyId,
+    };
+    if (cursor !== undefined) {
+      request.start_cursor = cursor;
+    }
+
+    const response = await client.pages.properties.retrieve(request as any) as any;
+    if (!Array.isArray(response?.results)) {
+      throw new Error("paginatePropertyValue: expected paginated property results");
+    }
+
+    const hasMore = response.has_more === true;
+    if (hasMore && response.results.length === 0) {
+      throw new Error(PROPERTY_PAGINATION_RUNAWAY_ERROR);
+    }
+
+    const nextCursor = typeof response.next_cursor === "string" ? response.next_cursor : undefined;
+    if (hasMore && (!nextCursor || nextCursor === cursor)) {
+      throw new Error(PROPERTY_PAGINATION_RUNAWAY_ERROR);
+    }
+
+    values.push(...response.results.map((item: any) => propertyItemValue(item, propertyType)));
+
+    if (cap > 0 && values.length >= cap) {
+      return {
+        values: values.slice(0, cap),
+        truncatedAtCap: values.length > cap || hasMore,
+      };
+    }
+
+    if (!hasMore) {
+      return { values, truncatedAtCap: false };
+    }
+
+    cursor = nextCursor;
+  }
+}
 
 /**
  * Resolve a database_id to its primary data_source_id.
@@ -944,3 +1077,6 @@ export async function listUsers(client: Client) {
 export async function getMe(client: Client) {
   return client.users.me({});
 }
+
+/** @internal */
+export { paginatePropertyValue };

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import {
   listChildren,
   listUsers,
   movePage,
+  paginatePageProperties,
   queryDatabase,
   restorePage,
   schemaToProperties,
@@ -41,6 +42,7 @@ import {
   updatePage,
   type PageParent,
   type SchemaEntry,
+  type TruncatedPropertyEntry,
 } from "./notion-client.js";
 import type { NotionBlock, RichText } from "./types.js";
 
@@ -638,7 +640,9 @@ Update a section of a page by heading name. Finds the heading, replaces everythi
   },
   {
     name: "read_page",
-    description: `Read a page and return its metadata plus markdown content. Recursively fetches nested blocks. Output uses the same conventions as input: toggles as +++ blocks, columns as ::: blocks, callouts as > [!NOTE], tables as | pipes |. If the page contains block types this server does not yet represent in markdown (e.g. synced_block, child_database, link_to_page), those blocks are omitted from the markdown AND listed in a \`warnings\` field with their ids and types. Do NOT round-trip the markdown back through replace_content when warnings are present — the omitted blocks will be deleted from the page.`,
+    description: `Read a page and return its metadata plus markdown content. Recursively fetches nested blocks. Output uses the same conventions as input: toggles as +++ blocks, columns as ::: blocks, callouts as > [!NOTE], tables as | pipes |. If the page contains block types this server does not yet represent in markdown (e.g. synced_block, child_database, link_to_page), those blocks are omitted from the markdown AND listed in a \`warnings\` field with their ids and types. Do NOT round-trip the markdown back through replace_content when warnings are present — the omitted blocks will be deleted from the page.
+
+Long titles: when a page title exceeds 25 rich_text segments (uncommon in practice), the response paginates the title up to max_property_items (default 75). If the cap is hit, the response includes a truncated_properties warning with a how_to_fetch_all hint. Call again with max_property_items: 0 for unlimited or with a larger cap number.`,
     inputSchema: {
       type: "object",
       properties: {
@@ -650,6 +654,11 @@ Update a section of a page by heading name. Finds the heading, replaces everythi
         max_blocks: {
           type: "number",
           description: "Maximum top-level blocks to return. Omit to return all.",
+        },
+        max_property_items: {
+          type: "number",
+          description:
+            "Max rich_text segments returned when a page title exceeds 25 segments (uncommon in practice). Default 75. Set to 0 for unlimited. Negative values rejected. When the cap is hit, the response includes a truncated_properties warning with a how_to_fetch_all hint.",
         },
       },
       required: ["page_id"],
@@ -840,7 +849,9 @@ At least one of \`title\`, \`properties\`, or \`in_trash\` must be provided. Emp
 - Checkbox: { "property": "Urgent", "checkbox": { "equals": true } }
 - Date after: { "property": "Due", "date": { "after": "2025-01-01" } }
 - Combine: { "and": [...] } or { "or": [...] }
-Call get_database first to see available properties and valid options.`,
+Call get_database first to see available properties and valid options.
+
+Response shape: returns { results: Array<entry>, warnings?: Array<warning> }. The results key is always present; warnings is included only when something needs the caller's attention. One possible warning code is truncated_properties, which fires when any multi-value property (title, rich_text, relation, people) exceeded max_property_items. Default cap is 75 items per property. If you see that warning, call again with max_property_items: 0 for unlimited, or with a larger cap number such as max_property_items: 500, to fetch the full set.`,
     inputSchema: {
       type: "object",
       properties: {
@@ -854,6 +865,11 @@ Call get_database first to see available properties and valid options.`,
         text: {
           type: "string",
           description: "Search text \u2014 matches across all text fields (title, rich_text, url, email, phone)",
+        },
+        max_property_items: {
+          type: "number",
+          description:
+            "Max items returned per multi-value property (title, rich_text, relation, people). Default 75. Set to 0 for unlimited. Negative values rejected. When the cap is hit, the response includes a truncated_properties warning with a how_to_fetch_all hint.",
         },
       },
       required: ["database_id"],
@@ -1255,12 +1271,29 @@ export function createServer(
         }
         case "read_page": {
           const notion = notionClientFactory();
-          const { page_id, include_metadata, max_blocks } = args as {
+          const { page_id, include_metadata, max_blocks, max_property_items } = args as {
             page_id: string;
             include_metadata?: boolean;
             max_blocks?: number;
+            max_property_items?: unknown;
           };
-          const page = await getPage(notion, page_id);
+          const cap = max_property_items === undefined ? 75 : max_property_items;
+          if (
+            typeof cap !== "number" ||
+            !Number.isFinite(cap) ||
+            cap < 0 ||
+            !Number.isInteger(cap)
+          ) {
+            throw new Error(
+              "read_page: `max_property_items` must be a non-negative integer. Use 0 for unlimited.",
+            );
+          }
+
+          const rawPage = await getPage(notion, page_id);
+          const { page, warnings: propertyWarnings } = await paginatePageProperties(notion, rawPage, {
+            maxPropertyItems: cap,
+            onlyTypes: ["title"],
+          });
 
           let blocks: NotionBlock[];
           let hasMore = false;
@@ -1285,8 +1318,19 @@ export function createServer(
             response.has_more = true;
           }
 
+          const warnings: unknown[] = [];
           if (ctx.omitted.length > 0) {
-            response.warnings = [{ code: "omitted_block_types", blocks: ctx.omitted }];
+            warnings.push({ code: "omitted_block_types", blocks: ctx.omitted });
+          }
+          if (propertyWarnings.length > 0) {
+            warnings.push({
+              code: "truncated_properties",
+              properties: propertyWarnings,
+              how_to_fetch_all: "Call again with max_property_items: 0 to fetch all items, or raise the cap to a larger number.",
+            });
+          }
+          if (warnings.length > 0) {
+            response.warnings = warnings;
           }
 
           if (include_metadata) {
@@ -1469,12 +1513,24 @@ export function createServer(
         }
         case "query_database": {
           const notion = notionClientFactory();
-          const { database_id, filter, sorts, text } = args as {
+          const { database_id, filter, sorts, text, max_property_items } = args as {
             database_id: string;
             filter?: Record<string, unknown>;
             sorts?: unknown[];
             text?: string;
+            max_property_items?: unknown;
           };
+          const cap = max_property_items === undefined ? 75 : max_property_items;
+          if (
+            typeof cap !== "number" ||
+            !Number.isFinite(cap) ||
+            cap < 0 ||
+            !Number.isInteger(cap)
+          ) {
+            throw new Error(
+              "query_database: `max_property_items` must be a non-negative integer. Use 0 for unlimited.",
+            );
+          }
           let effectiveFilter = filter;
           if (text) {
             const textFilter = await buildTextFilter(notion, database_id, text);
@@ -1482,8 +1538,36 @@ export function createServer(
               effectiveFilter = filter ? { and: [textFilter, filter] } : textFilter;
             }
           }
-          const results = await queryDatabase(notion, database_id, effectiveFilter, sorts) as any[];
-          return textResponse(results.map(simplifyEntry));
+          const rawResults = await queryDatabase(notion, database_id, effectiveFilter, sorts) as any[];
+          const collectedWarnings: TruncatedPropertyEntry[] = [];
+          const paginatedResults: any[] = [];
+
+          for (const row of rawResults) {
+            const { page, warnings } = await paginatePageProperties(notion, row, {
+              maxPropertyItems: cap,
+            });
+            paginatedResults.push(page);
+            if (warnings.length > 0) {
+              collectedWarnings.push(...warnings);
+            }
+          }
+
+          const response: {
+            results: Record<string, unknown>[];
+            warnings?: unknown[];
+          } = {
+            results: paginatedResults.map(simplifyEntry),
+          };
+
+          if (collectedWarnings.length > 0) {
+            response.warnings = [{
+              code: "truncated_properties",
+              properties: collectedWarnings,
+              how_to_fetch_all: "Call again with max_property_items: 0 to fetch all items, or raise the cap to a larger number.",
+            }];
+          }
+
+          return textResponse(response);
         }
         case "add_database_entry": {
           const notion = notionClientFactory();

--- a/tests/e2e/live-mcp.test.ts
+++ b/tests/e2e/live-mcp.test.ts
@@ -308,7 +308,7 @@ describe.skipIf(!env.shouldRun)(
       } finally {
         await client?.close();
       }
-    }, 60_000);
+    }, 300_000);
 
     it("A1: auth / transport smoke", async () => {
       expect(client).toBeTruthy();

--- a/tests/e2e/live-mcp.test.ts
+++ b/tests/e2e/live-mcp.test.ts
@@ -84,6 +84,17 @@ type AddDatabaseEntryResponse = {
   error?: string;
 };
 
+type QueryDatabaseWarning = {
+  code?: string;
+  properties?: Array<Record<string, unknown>>;
+  how_to_fetch_all?: string;
+};
+
+type QueryDatabaseResponse = {
+  results: Array<Record<string, unknown>>;
+  warnings?: QueryDatabaseWarning[];
+};
+
 type ReadPageResponse = {
   id: string;
   title: string | null;
@@ -431,9 +442,10 @@ describe.skipIf(!env.shouldRun)(
       // Notion evaluates formulas asynchronously; poll a few times before asserting.
       let row: Record<string, unknown> | undefined;
       for (let attempt = 0; attempt < 6; attempt += 1) {
-        const rows = await callTool<Array<Record<string, unknown>>>(client, "query_database", {
+        const rowsResponse = await callTool<QueryDatabaseResponse>(client, "query_database", {
           database_id: created.id,
         });
+        const rows = rowsResponse.results;
         row = rows.find((candidate) => candidate.Task === "row1");
         if (row && row.Score !== null && row.Score !== undefined) {
           break;
@@ -494,12 +506,14 @@ describe.skipIf(!env.shouldRun)(
       ctx.createdPageIds.push(entry.id);
 
       // Notion evaluates formulas asynchronously; poll a few times before asserting.
+      let rowsResponse: QueryDatabaseResponse = { results: [] };
       let rows: Array<Record<string, unknown>> = [];
       let row: Record<string, unknown> | undefined;
       for (let attempt = 0; attempt < 6; attempt += 1) {
-        rows = await callTool<Array<Record<string, unknown>>>(client, "query_database", {
+        rowsResponse = await callTool<QueryDatabaseResponse>(client, "query_database", {
           database_id: created.id,
         });
+        rows = rowsResponse.results;
         row = rows.find((candidate) => candidate.Title === "row1");
         if (row && row.Formula !== null && row.Formula !== undefined) {
           break;
@@ -507,8 +521,8 @@ describe.skipIf(!env.shouldRun)(
         await new Promise((resolve) => setTimeout(resolve, 2_000));
       }
 
-      expect(Array.isArray(rows)).toBe(true);
-      expect(Object.prototype.hasOwnProperty.call(rows, "warnings")).toBe(false);
+      expect(Array.isArray(rowsResponse.results)).toBe(true);
+      expect(Object.prototype.hasOwnProperty.call(rowsResponse, "warnings")).toBe(false);
       expect(row).toBeDefined();
       expect(row).toEqual(expect.objectContaining({ Title: "row1", Count: 5 }));
       expect(row?.Formula).not.toBeNull();
@@ -623,15 +637,145 @@ describe.skipIf(!env.shouldRun)(
       expect(entry.error).toBeUndefined();
       ctx.createdPageIds.push(entry.id);
 
-      const rows = await callTool<Array<Record<string, unknown>>>(client, "query_database", {
+      const rowsResponse = await callTool<QueryDatabaseResponse>(client, "query_database", {
         database_id: created.id,
       });
+      const rows = rowsResponse.results;
 
       const row = rows.find((candidate) => candidate.Title === "r1");
       expect(row).toBeDefined();
       expect(Array.isArray(row?.Owner)).toBe(true);
       expect((row?.Owner as unknown[]).length).toBeGreaterThan(0);
     }, 30_000);
+
+    describe("relation pagination", () => {
+      it("returns 27 relation entries without a warning at the default cap", async () => {
+        const source = await callTool<CreateDatabaseResponse>(client, "create_database", {
+          parent_page_id: ctx.sandboxId!,
+          title: "P6 relation source 27",
+          schema: [
+            { name: "Name", type: "title" },
+          ],
+        });
+        expect(source.error).toBeUndefined();
+        ctx.createdPageIds.push(source.id);
+
+        const sourceEntryIds: string[] = [];
+        for (let index = 0; index < 27; index += 1) {
+          const entry = await callTool<AddDatabaseEntryResponse>(client, "add_database_entry", {
+            database_id: source.id,
+            properties: {
+              Name: `source ${index + 1}`,
+            },
+          });
+          expect(entry.error).toBeUndefined();
+          ctx.createdPageIds.push(entry.id);
+          sourceEntryIds.push(entry.id);
+          await new Promise((resolve) => setTimeout(resolve, 350));
+        }
+
+        const target = await callTool<CreateDatabaseResponse>(client, "create_database", {
+          parent_page_id: ctx.sandboxId!,
+          title: "P6 relation target 27",
+          schema: [
+            { name: "Name", type: "title" },
+            { name: "Refs", type: "relation", data_source_id: source.id },
+          ],
+        });
+        expect(target.error).toBeUndefined();
+        ctx.createdPageIds.push(target.id);
+
+        const targetEntry = await callTool<AddDatabaseEntryResponse>(client, "add_database_entry", {
+          database_id: target.id,
+          properties: {
+            Name: "target",
+            Refs: sourceEntryIds,
+          },
+        });
+        expect(targetEntry.error).toBeUndefined();
+        ctx.createdPageIds.push(targetEntry.id);
+
+        const rowsResponse = await callTool<QueryDatabaseResponse>(client, "query_database", {
+          database_id: target.id,
+        });
+
+        expect(rowsResponse.results).toHaveLength(1);
+        const row = rowsResponse.results[0];
+        expect(Array.isArray(row.Refs)).toBe(true);
+        expect((row.Refs as unknown[])).toHaveLength(27);
+        expect(Object.prototype.hasOwnProperty.call(rowsResponse, "warnings")).toBe(false);
+      }, 180_000);
+
+      it("returns 75 relation entries with a cap warning at the default cap", async () => {
+        const source = await callTool<CreateDatabaseResponse>(client, "create_database", {
+          parent_page_id: ctx.sandboxId!,
+          title: "P6 relation source 85",
+          schema: [
+            { name: "Name", type: "title" },
+          ],
+        });
+        expect(source.error).toBeUndefined();
+        ctx.createdPageIds.push(source.id);
+
+        const sourceEntryIds: string[] = [];
+        for (let index = 0; index < 85; index += 1) {
+          const entry = await callTool<AddDatabaseEntryResponse>(client, "add_database_entry", {
+            database_id: source.id,
+            properties: {
+              Name: `source ${index + 1}`,
+            },
+          });
+          expect(entry.error).toBeUndefined();
+          ctx.createdPageIds.push(entry.id);
+          sourceEntryIds.push(entry.id);
+          await new Promise((resolve) => setTimeout(resolve, 350));
+        }
+
+        const target = await callTool<CreateDatabaseResponse>(client, "create_database", {
+          parent_page_id: ctx.sandboxId!,
+          title: "P6 relation target 85",
+          schema: [
+            { name: "Name", type: "title" },
+            { name: "Refs", type: "relation", data_source_id: source.id },
+          ],
+        });
+        expect(target.error).toBeUndefined();
+        ctx.createdPageIds.push(target.id);
+
+        const targetEntry = await callTool<AddDatabaseEntryResponse>(client, "add_database_entry", {
+          database_id: target.id,
+          properties: {
+            Name: "target",
+            Refs: sourceEntryIds,
+          },
+        });
+        expect(targetEntry.error).toBeUndefined();
+        ctx.createdPageIds.push(targetEntry.id);
+
+        const rowsResponse = await callTool<QueryDatabaseResponse>(client, "query_database", {
+          database_id: target.id,
+        });
+
+        expect(rowsResponse.results).toHaveLength(1);
+        const row = rowsResponse.results[0];
+        expect(Array.isArray(row.Refs)).toBe(true);
+        expect((row.Refs as unknown[])).toHaveLength(75);
+        expect(rowsResponse.warnings).toHaveLength(1);
+        const warning = rowsResponse.warnings?.[0];
+        expect(warning?.code).toBe("truncated_properties");
+        expect(warning?.properties).toHaveLength(1);
+        expect(warning?.properties?.[0]).toEqual(
+          expect.objectContaining({
+            name: "Refs",
+            type: "relation",
+            returned_count: 75,
+            cap: 75,
+          }),
+        );
+        expect(warning?.how_to_fetch_all).toEqual(expect.any(String));
+        expect(warning?.how_to_fetch_all).toContain("max_property_items");
+      }, 180_000);
+    });
 
     it("C6: unique_id schema with prefix", async () => {
       const created = await callTool<CreateDatabaseResponse>(client, "create_database", {
@@ -667,9 +811,10 @@ describe.skipIf(!env.shouldRun)(
       expect(entry.error).toBeUndefined();
       ctx.createdPageIds.push(entry.id);
 
-      const rows = await callTool<Array<Record<string, unknown>>>(client, "query_database", {
+      const rowsResponse = await callTool<QueryDatabaseResponse>(client, "query_database", {
         database_id: created.id,
       });
+      const rows = rowsResponse.results;
 
       const row = rows.find((candidate) => candidate.Title === "row1");
       expect(row).toBeDefined();

--- a/tests/paginate-page-properties.test.ts
+++ b/tests/paginate-page-properties.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { paginatePageProperties } from "../src/notion-client.js";
+
+function makeClient(pages: Array<{ results: any[]; next_cursor: string | null; has_more: boolean }>) {
+  let callIdx = 0;
+  const retrieve = vi.fn(async () => pages[callIdx++]);
+  return { client: { pages: { properties: { retrieve } } } as any, retrieve };
+}
+
+function relationValues(count: number, offset = 0) {
+  return Array.from({ length: count }, (_, index) => ({ id: `rel-${offset + index}` }));
+}
+
+function relationItems(count: number, offset = 0) {
+  return relationValues(count, offset).map((relation) => ({
+    type: "relation",
+    relation,
+  }));
+}
+
+function peopleValues(count: number, offset = 0) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `user-${offset + index}`,
+    name: `User ${offset + index}`,
+  }));
+}
+
+function peopleItems(count: number, offset = 0) {
+  return peopleValues(count, offset).map((people) => ({
+    type: "people",
+    people,
+  }));
+}
+
+function richTextValues(count: number, prefix = "text") {
+  return Array.from({ length: count }, (_, index) => ({
+    type: "text",
+    plain_text: `${prefix}-${index}`,
+    text: { content: `${prefix}-${index}` },
+  }));
+}
+
+function titleItems(count: number) {
+  return richTextValues(count, "title").map((title) => ({
+    type: "title",
+    title,
+  }));
+}
+
+function richTextItems(count: number) {
+  return richTextValues(count, "text").map((rich_text) => ({
+    type: "rich_text",
+    rich_text,
+  }));
+}
+
+function pageWithProperties(properties: Record<string, any>) {
+  return {
+    object: "page",
+    id: "page-1",
+    properties,
+  };
+}
+
+describe("paginatePageProperties", () => {
+  it("paginates one relation property beyond the initial 25 values without mutating input", async () => {
+    const inputPage = pageWithProperties({
+      Ref: {
+        id: "prop-ref",
+        type: "relation",
+        relation: relationValues(25),
+      },
+    });
+    const { client } = makeClient([
+      { results: relationItems(27), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePageProperties(client, inputPage, { maxPropertyItems: 75 });
+
+    expect(result.page).not.toBe(inputPage);
+    expect(result.page.properties.Ref.relation).toHaveLength(27);
+    expect(result.warnings).toEqual([]);
+    expect(inputPage.properties.Ref.relation).toHaveLength(25);
+  });
+
+  it("keeps exactly 25 relation values when the full retrieved value has no more pages", async () => {
+    const inputPage = pageWithProperties({
+      Ref: {
+        id: "prop-ref",
+        type: "relation",
+        relation: relationValues(25),
+      },
+    });
+    const { client } = makeClient([
+      { results: relationItems(25), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePageProperties(client, inputPage, { maxPropertyItems: 75 });
+
+    expect(result.page.properties.Ref.relation).toHaveLength(25);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("skips multi select properties with 25 values", async () => {
+    const inputPage = pageWithProperties({
+      Tags: {
+        id: "prop-tags",
+        type: "multi_select",
+        multi_select: Array.from({ length: 25 }, (_, index) => ({ name: `tag-${index}` })),
+      },
+    });
+    const { client, retrieve } = makeClient([]);
+
+    const result = await paginatePageProperties(client, inputPage, { maxPropertyItems: 75 });
+
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(result.page.properties).toEqual(inputPage.properties);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns when a people property is truncated at the cap", async () => {
+    const inputPage = pageWithProperties({
+      Assignees: {
+        id: "prop-people",
+        type: "people",
+        people: peopleValues(25),
+      },
+    });
+    const { client } = makeClient([
+      { results: peopleItems(200), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePageProperties(client, inputPage, { maxPropertyItems: 75 });
+
+    expect(result.warnings[0]).toEqual({
+      name: "Assignees",
+      type: "people",
+      returned_count: 75,
+      cap: 75,
+    });
+    expect(result.page.properties.Assignees.people).toHaveLength(75);
+  });
+
+  it("paginates three truncated properties sequentially and reports three warnings", async () => {
+    const inputPage = pageWithProperties({
+      Ref: {
+        id: "prop-ref",
+        type: "relation",
+        relation: relationValues(25),
+      },
+      Assignees: {
+        id: "prop-people",
+        type: "people",
+        people: peopleValues(25),
+      },
+      Name: {
+        id: "prop-title",
+        type: "title",
+        title: richTextValues(25, "title"),
+      },
+    });
+    const { client, retrieve } = makeClient([
+      { results: relationItems(200), next_cursor: null, has_more: false },
+      { results: peopleItems(200), next_cursor: null, has_more: false },
+      { results: titleItems(200), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePageProperties(client, inputPage, { maxPropertyItems: 75 });
+
+    expect(retrieve.mock.calls).toHaveLength(3);
+    expect(result.warnings).toEqual([
+      { name: "Ref", type: "relation", returned_count: 75, cap: 75 },
+      { name: "Assignees", type: "people", returned_count: 75, cap: 75 },
+      { name: "Name", type: "title", returned_count: 75, cap: 75 },
+    ]);
+    expect(result.page.properties.Ref.relation).toHaveLength(75);
+    expect(result.page.properties.Assignees.people).toHaveLength(75);
+    expect(result.page.properties.Name.title).toHaveLength(75);
+  });
+
+  it("paginates only requested property types", async () => {
+    const inputPage = pageWithProperties({
+      Ref: {
+        id: "prop-ref",
+        type: "relation",
+        relation: relationValues(25),
+      },
+      Assignees: {
+        id: "prop-people",
+        type: "people",
+        people: peopleValues(25),
+      },
+      Name: {
+        id: "prop-title",
+        type: "title",
+        title: richTextValues(25, "title"),
+      },
+    });
+    const { client, retrieve } = makeClient([
+      { results: titleItems(30), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePageProperties(client, inputPage, {
+      maxPropertyItems: 75,
+      onlyTypes: ["title"],
+    });
+
+    expect(retrieve.mock.calls).toHaveLength(1);
+    expect(result.page.properties.Ref.relation).toHaveLength(25);
+    expect(result.page.properties.Assignees.people).toHaveLength(25);
+    expect(result.page.properties.Name.title).toHaveLength(30);
+  });
+
+  it("does not paginate when no truncatable property has length 25", async () => {
+    const inputPage = pageWithProperties({
+      Ref: {
+        id: "prop-ref",
+        type: "relation",
+        relation: relationValues(24),
+      },
+      Assignees: {
+        id: "prop-people",
+        type: "people",
+        people: peopleValues(26),
+      },
+      Name: {
+        id: "prop-title",
+        type: "title",
+        title: richTextValues(1, "title"),
+      },
+    });
+    const { client, retrieve } = makeClient([]);
+
+    const result = await paginatePageProperties(client, inputPage, { maxPropertyItems: 75 });
+
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(result.warnings).toEqual([]);
+    expect(result.page.properties).toEqual(inputPage.properties);
+  });
+
+  it("does not mutate the input page while replacing paginated properties", async () => {
+    const inputPage = pageWithProperties({
+      Ref: {
+        id: "prop-ref",
+        type: "relation",
+        relation: relationValues(25),
+      },
+    });
+    const { client } = makeClient([
+      { results: relationItems(30), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePageProperties(client, inputPage, { maxPropertyItems: 75 });
+
+    expect(result.page).not.toBe(inputPage);
+    expect(inputPage.properties.Ref.relation).toHaveLength(25);
+    expect(result.page.properties.Ref.relation).toHaveLength(30);
+  });
+
+  it("paginates rich text properties with 25 input values", async () => {
+    const inputPage = pageWithProperties({
+      Notes: {
+        id: "prop-rich-text",
+        type: "rich_text",
+        rich_text: richTextValues(25, "text"),
+      },
+    });
+    const { client } = makeClient([
+      { results: richTextItems(30), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePageProperties(client, inputPage, { maxPropertyItems: 75 });
+
+    expect(result.page.properties.Notes.rich_text).toHaveLength(30);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/tests/paginate-property-value.test.ts
+++ b/tests/paginate-property-value.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { paginatePropertyValue } from "../src/notion-client.js";
+
+function makeStub(pages: Array<{ results: any[]; next_cursor: string | null; has_more: boolean }>) {
+  let callIdx = 0;
+  const calls: any[] = [];
+  const retrieve = vi.fn(async (args: any) => {
+    calls.push(args);
+    return pages[callIdx++];
+  });
+  return { client: { pages: { properties: { retrieve } } } as any, retrieve, calls };
+}
+
+function relationItems(count: number, offset = 0) {
+  return Array.from({ length: count }, (_, index) => ({
+    type: "relation",
+    relation: { id: `rel-${offset + index}` },
+  }));
+}
+
+function titleItems(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    type: "title",
+    title: {
+      type: "text",
+      plain_text: `title-${index}`,
+      text: { content: `title-${index}` },
+    },
+  }));
+}
+
+function richTextItems(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    type: "rich_text",
+    rich_text: {
+      type: "text",
+      plain_text: `text-${index}`,
+      text: { content: `text-${index}` },
+    },
+  }));
+}
+
+function peopleItems(count: number, offset = 0) {
+  return Array.from({ length: count }, (_, index) => ({
+    type: "people",
+    people: { id: `user-${offset + index}`, name: `User ${offset + index}` },
+  }));
+}
+
+describe("paginatePropertyValue", () => {
+  it("returns a single page relation value with more than 25 items", async () => {
+    const { client, retrieve, calls } = makeStub([
+      { results: relationItems(27), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePropertyValue(client, "page-1", "prop-1", "relation", 75);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(calls[0]).toEqual({ page_id: "page-1", property_id: "prop-1" });
+    expect(result.values).toHaveLength(27);
+    expect(result.values).toEqual(
+      Array.from({ length: 27 }, (_, index) => ({ id: `rel-${index}` })),
+    );
+    expect(result.truncatedAtCap).toBe(false);
+  });
+
+  it("stops relation pagination at the cap when more pages exist", async () => {
+    const { client, retrieve } = makeStub([
+      { results: relationItems(75), next_cursor: "c1", has_more: true },
+      { results: relationItems(75, 75), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePropertyValue(client, "page-1", "prop-1", "relation", 75);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(result.values).toHaveLength(75);
+    expect(result.truncatedAtCap).toBe(true);
+  });
+
+  it("fetches all relation items when cap is zero", async () => {
+    const { client, retrieve, calls } = makeStub([
+      { results: relationItems(75), next_cursor: "c1", has_more: true },
+      { results: relationItems(75, 75), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePropertyValue(client, "page-1", "prop-1", "relation", 0);
+
+    expect(retrieve).toHaveBeenCalledTimes(2);
+    expect(calls[1]).toEqual({ page_id: "page-1", property_id: "prop-1", start_cursor: "c1" });
+    expect(result.values).toHaveLength(150);
+    expect(result.values[149]).toEqual({ id: "rel-149" });
+    expect(result.truncatedAtCap).toBe(false);
+  });
+
+  it("reshapes title property items to rich text values", async () => {
+    const { client, retrieve } = makeStub([
+      { results: titleItems(30), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePropertyValue(client, "page-1", "title-prop", "title", 75);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(result.values).toHaveLength(30);
+    expect(result.values[0]).toEqual({
+      type: "text",
+      plain_text: "title-0",
+      text: { content: "title-0" },
+    });
+    expect(result.truncatedAtCap).toBe(false);
+  });
+
+  it("returns exactly 25 rich text items without truncation when no more pages exist", async () => {
+    const { client, retrieve } = makeStub([
+      { results: richTextItems(25), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePropertyValue(client, "page-1", "text-prop", "rich_text", 75);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(result.values).toHaveLength(25);
+    expect(result.values[24]).toEqual({
+      type: "text",
+      plain_text: "text-24",
+      text: { content: "text-24" },
+    });
+    expect(result.truncatedAtCap).toBe(false);
+  });
+
+  it("fetches all people items across three pages when cap is zero", async () => {
+    const { client, retrieve } = makeStub([
+      { results: peopleItems(100), next_cursor: "c1", has_more: true },
+      { results: peopleItems(100, 100), next_cursor: "c2", has_more: true },
+      { results: peopleItems(100, 200), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePropertyValue(client, "page-1", "people-prop", "people", 0);
+
+    expect(retrieve).toHaveBeenCalledTimes(3);
+    expect(result.values).toHaveLength(300);
+    expect(result.values[299]).toEqual({ id: "user-299", name: "User 299" });
+    expect(result.truncatedAtCap).toBe(false);
+  });
+
+  it("trims overshoot to the cap and reports truncation", async () => {
+    const { client, retrieve } = makeStub([
+      { results: relationItems(80), next_cursor: null, has_more: false },
+    ]);
+
+    const result = await paginatePropertyValue(client, "page-1", "prop-1", "relation", 75);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(result.values).toHaveLength(75);
+    expect(result.values[74]).toEqual({ id: "rel-74" });
+    expect(result.truncatedAtCap).toBe(true);
+  });
+
+  it("throws when a paginated response has no results", async () => {
+    const { client } = makeStub([
+      { results: [], next_cursor: null, has_more: true },
+    ]);
+
+    await expect(
+      paginatePropertyValue(client, "page-1", "prop-1", "relation", 0),
+    ).rejects.toThrow(/runaway/);
+  });
+
+  it("throws when the next cursor does not advance", async () => {
+    const { client } = makeStub([
+      { results: relationItems(1), next_cursor: "x", has_more: true },
+      { results: relationItems(1, 1), next_cursor: "x", has_more: true },
+    ]);
+
+    await expect(
+      paginatePropertyValue(client, "page-1", "prop-1", "relation", 0),
+    ).rejects.toThrow(/runaway/);
+  });
+});

--- a/tests/property-roundtrip.test.ts
+++ b/tests/property-roundtrip.test.ts
@@ -347,9 +347,13 @@ describe("property schema roundtrip", () => {
       const createCall = notion.pages.create.mock.calls[0][0];
       expect(createCall.properties.Owner).toEqual({ people: [{ id: "user-1" }] });
 
-      const rows = parseToolJson<Array<Record<string, unknown>>>(
+      const rowsResponse = parseToolJson<{
+        results: Array<Record<string, unknown>>;
+        warnings?: unknown[];
+      }>(
         await client.callTool({ name: "query_database", arguments: { database_id: created.id } }),
       );
+      const rows = rowsResponse.results;
       expect(rows).toHaveLength(1);
       expect(rows[0]).toEqual(expect.objectContaining({ Owner: ["user-1"] }));
     } finally {

--- a/tests/query-database-pagination.test.ts
+++ b/tests/query-database-pagination.test.ts
@@ -1,0 +1,318 @@
+import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createServer } from "../src/server.js";
+
+function parseToolText(result: { content?: Array<{ type: string; text?: string }> }) {
+  const text = result.content?.find((item) => item.type === "text")?.text;
+  if (!text) throw new Error("expected text content");
+  return text;
+}
+
+function parseToolJson<T>(result: { content?: Array<{ type: string; text?: string }> }): T {
+  return JSON.parse(parseToolText(result)) as T;
+}
+
+async function connect(notion: any) {
+  const server = createServer(() => notion, {});
+  const client = new McpClient(
+    { name: "query-database-pagination-test", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  const [a, b] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(b), client.connect(a)]);
+  return {
+    client,
+    async close() {
+      await Promise.all([a.close(), b.close()]);
+    },
+  };
+}
+
+type QueryDatabaseResponse = {
+  results: Array<Record<string, unknown>>;
+  warnings?: Array<{
+    code: string;
+    properties: Array<{
+      name: string;
+      type: string;
+      returned_count: number;
+      cap: number;
+    }>;
+    how_to_fetch_all?: string;
+  }>;
+};
+
+const relationValues = (count: number, prefix = "target") => (
+  Array.from({ length: count }, (_, index) => ({ id: `${prefix}-${index + 1}` }))
+);
+
+const relationItems = (count: number, prefix = "target") => (
+  relationValues(count, prefix).map((relation) => ({
+    object: "property_item",
+    id: "p-ref",
+    type: "relation",
+    relation,
+  }))
+);
+
+function makeQueryPage(id: string, relationCount: number) {
+  return {
+    id,
+    object: "page",
+    properties: {
+      Ref: {
+        id: "p-ref",
+        type: "relation",
+        relation: relationValues(relationCount),
+      },
+    },
+  };
+}
+
+function makeNotionStub(opts: {
+  rows: any[];
+  retrievePages?: Array<{
+    results: any[];
+    has_more: boolean;
+    next_cursor: string | null;
+  }>;
+}) {
+  const notion = {
+    databases: {
+      retrieve: vi.fn(async () => ({
+        id: "db-1",
+        data_sources: [{ id: "ds-1" }],
+      })),
+    },
+    dataSources: {
+      query: vi.fn(async () => ({
+        results: opts.rows,
+        has_more: false,
+        next_cursor: null,
+      })),
+    },
+    pages: {
+      properties: {
+        retrieve: vi.fn(async () => {
+          const next = opts.retrievePages?.shift();
+          if (!next) {
+            throw new Error("unexpected pages.properties.retrieve call");
+          }
+          return next;
+        }),
+      },
+    },
+  };
+
+  return notion;
+}
+
+describe("query_database property pagination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a 30-item relation under the default cap with no warnings", async () => {
+    const notion = makeNotionStub({
+      rows: [makeQueryPage("page-1", 25)],
+      retrievePages: [{
+        results: relationItems(30),
+        has_more: false,
+        next_cursor: null,
+      }],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const result = parseToolJson<QueryDatabaseResponse>(
+        await client.callTool({ name: "query_database", arguments: { database_id: "db-1" } }),
+      );
+
+      expect(Array.isArray(result)).toBe(false);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].Ref).toHaveLength(30);
+      expect(result.warnings).toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  it("caps a 200-item relation at 75 by default and emits one warning", async () => {
+    const notion = makeNotionStub({
+      rows: [makeQueryPage("page-1", 25)],
+      retrievePages: [
+        {
+          results: relationItems(75),
+          has_more: true,
+          next_cursor: "c1",
+        },
+        {
+          results: relationItems(75, "target-page-2"),
+          has_more: true,
+          next_cursor: "c2",
+        },
+        {
+          results: relationItems(50, "target-page-3"),
+          has_more: false,
+          next_cursor: null,
+        },
+      ],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const result = parseToolJson<QueryDatabaseResponse>(
+        await client.callTool({ name: "query_database", arguments: { database_id: "db-1" } }),
+      );
+
+      expect(result.results[0].Ref).toHaveLength(75);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings?.[0].code).toBe("truncated_properties");
+      expect(result.warnings?.[0].properties).toHaveLength(1);
+      expect(result.warnings?.[0].properties[0]).toEqual({
+        name: "Ref",
+        type: "relation",
+        returned_count: 75,
+        cap: 75,
+      });
+      expect(result.warnings?.[0].how_to_fetch_all).toContain("max_property_items");
+      expect(notion.pages.properties.retrieve).toHaveBeenCalledTimes(1);
+    } finally {
+      await close();
+    }
+  });
+
+  it("fetches a 300-item relation with max_property_items set to 0", async () => {
+    const notion = makeNotionStub({
+      rows: [makeQueryPage("page-1", 25)],
+      retrievePages: [
+        {
+          results: relationItems(100, "target-page-1"),
+          has_more: true,
+          next_cursor: "c1",
+        },
+        {
+          results: relationItems(100, "target-page-2"),
+          has_more: true,
+          next_cursor: "c2",
+        },
+        {
+          results: relationItems(100, "target-page-3"),
+          has_more: false,
+          next_cursor: null,
+        },
+      ],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const result = parseToolJson<QueryDatabaseResponse>(
+        await client.callTool({
+          name: "query_database",
+          arguments: { database_id: "db-1", max_property_items: 0 },
+        }),
+      );
+
+      expect(result.results[0].Ref).toHaveLength(300);
+      expect(result.warnings).toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  it("uses an explicit max_property_items cap", async () => {
+    const notion = makeNotionStub({
+      rows: [makeQueryPage("page-1", 25)],
+      retrievePages: [{
+        results: relationItems(50),
+        has_more: true,
+        next_cursor: "c1",
+      }],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const result = parseToolJson<QueryDatabaseResponse>(
+        await client.callTool({
+          name: "query_database",
+          arguments: { database_id: "db-1", max_property_items: 25 },
+        }),
+      );
+
+      expect(result.results[0].Ref).toHaveLength(25);
+      expect(result.warnings?.[0].properties[0].cap).toBe(25);
+    } finally {
+      await close();
+    }
+  });
+
+  it("rejects negative max_property_items before fetching page properties", async () => {
+    const notion = makeNotionStub({
+      rows: [makeQueryPage("page-1", 25)],
+      retrievePages: [{
+        results: relationItems(30),
+        has_more: false,
+        next_cursor: null,
+      }],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const result = parseToolJson<{ error?: string }>(
+        await client.callTool({
+          name: "query_database",
+          arguments: { database_id: "db-1", max_property_items: -1 },
+        }),
+      );
+
+      expect(result.error).toContain("max_property_items");
+      expect(notion.pages.properties.retrieve).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+
+  it("wraps zero-warning responses with exactly a results key", async () => {
+    const notion = makeNotionStub({
+      rows: [
+        makeQueryPage("page-1", 1),
+        makeQueryPage("page-2", 2),
+        makeQueryPage("page-3", 3),
+      ],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const result = parseToolJson<QueryDatabaseResponse>(
+        await client.callTool({ name: "query_database", arguments: { database_id: "db-1" } }),
+      );
+
+      expect(Array.isArray(result)).toBe(false);
+      expect(Object.keys(result)).toEqual(["results"]);
+      expect(result.results).toHaveLength(3);
+      expect(result.warnings).toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  it("wraps warning responses with results and warnings keys", async () => {
+    const notion = makeNotionStub({
+      rows: [makeQueryPage("page-1", 25)],
+      retrievePages: [{
+        results: relationItems(75),
+        has_more: true,
+        next_cursor: "c1",
+      }],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const result = parseToolJson<QueryDatabaseResponse>(
+        await client.callTool({ name: "query_database", arguments: { database_id: "db-1" } }),
+      );
+
+      expect(Array.isArray(result)).toBe(false);
+      expect(Object.keys(result)).toEqual(["results", "warnings"]);
+      expect(result.results).toHaveLength(1);
+      expect(result.warnings).toHaveLength(1);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/read-page-title-pagination.test.ts
+++ b/tests/read-page-title-pagination.test.ts
@@ -1,0 +1,338 @@
+import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createServer } from "../src/server.js";
+
+function parseToolText(result: { content?: Array<{ type: string; text?: string }> }) {
+  const text = result.content?.find((item) => item.type === "text")?.text;
+  if (!text) throw new Error("expected text content");
+  return text;
+}
+
+function parseToolJson<T>(result: { content?: Array<{ type: string; text?: string }> }): T {
+  return JSON.parse(parseToolText(result)) as T;
+}
+
+async function connect(notion: any) {
+  const server = createServer(() => notion, {});
+  const client = new McpClient(
+    { name: "read-page-title-pagination-test", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  const [a, b] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(b), client.connect(a)]);
+  return {
+    client,
+    async close() {
+      await Promise.all([a.close(), b.close()]);
+    },
+  };
+}
+
+type ReadPageResponse = {
+  title?: string;
+  warnings?: Array<Record<string, any>>;
+  error?: string;
+};
+
+const titleText = (count: number, content = "x") => (
+  Array.from({ length: count }, () => ({
+    plain_text: content,
+    type: "text",
+    text: { content },
+  }))
+);
+
+const titleItems = (count: number, content = "x") => (
+  titleText(count, content).map((title) => ({
+    object: "property_item",
+    id: "title-prop",
+    type: "title",
+    title,
+  }))
+);
+
+const relationValues = (count: number) => (
+  Array.from({ length: count }, (_, index) => ({ id: `target-${index + 1}` }))
+);
+
+function makePage(titleCount: number, extras: Record<string, any> = {}) {
+  return {
+    id: "page-1",
+    object: "page",
+    url: "https://notion.so/page-1",
+    properties: {
+      Name: {
+        id: "title-prop",
+        type: "title",
+        title: titleText(titleCount),
+      },
+      ...extras,
+    },
+  };
+}
+
+function makeNotionStub(opts: {
+  page: any;
+  retrievePages?: Array<{
+    results: any[];
+    has_more: boolean;
+    next_cursor: string | null;
+  }>;
+  blocks?: any[];
+}) {
+  return {
+    pages: {
+      retrieve: vi.fn(async () => opts.page),
+      properties: {
+        retrieve: vi.fn(async () => {
+          const next = opts.retrievePages?.shift();
+          if (!next) {
+            throw new Error("unexpected pages.properties.retrieve call");
+          }
+          return next;
+        }),
+      },
+    },
+    blocks: {
+      children: {
+        list: vi.fn(async () => ({
+          results: opts.blocks ?? [],
+          has_more: false,
+          next_cursor: null,
+        })),
+      },
+    },
+  };
+}
+
+describe("read_page title pagination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rehydrates a 30-item title under the default cap with no warnings", async () => {
+    const notion = makeNotionStub({
+      page: makePage(25),
+      retrievePages: [{
+        results: titleItems(30),
+        has_more: false,
+        next_cursor: null,
+      }],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const response = parseToolJson<ReadPageResponse>(
+        await client.callTool({ name: "read_page", arguments: { page_id: "page-1" } }),
+      );
+
+      expect(response.title).toBe("x".repeat(30));
+      expect(response.warnings).toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  it("caps a 200-item title at 75 by default and emits a truncated_properties warning", async () => {
+    const notion = makeNotionStub({
+      page: makePage(25),
+      retrievePages: [
+        {
+          results: titleItems(75),
+          has_more: true,
+          next_cursor: "c1",
+        },
+        {
+          results: titleItems(75),
+          has_more: true,
+          next_cursor: "c2",
+        },
+        {
+          results: titleItems(50),
+          has_more: false,
+          next_cursor: null,
+        },
+      ],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const response = parseToolJson<ReadPageResponse>(
+        await client.callTool({ name: "read_page", arguments: { page_id: "page-1" } }),
+      );
+
+      expect(response.title).toHaveLength(75);
+      expect(response.warnings).toEqual([
+        {
+          code: "truncated_properties",
+          properties: [{
+            name: "Name",
+            type: "title",
+            returned_count: 75,
+            cap: 75,
+          }],
+          how_to_fetch_all: expect.stringContaining("max_property_items"),
+        },
+      ]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("does not paginate a title under 25 segments", async () => {
+    const notion = makeNotionStub({
+      page: makePage(10),
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const response = parseToolJson<ReadPageResponse>(
+        await client.callTool({ name: "read_page", arguments: { page_id: "page-1" } }),
+      );
+
+      expect(response.title).toBe("x".repeat(10));
+      expect(response.warnings).toBeUndefined();
+      expect(notion.pages.properties.retrieve).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+
+  it("paginates only the title property when relation is also length 25", async () => {
+    const notion = makeNotionStub({
+      page: makePage(25, {
+        Ref: {
+          id: "relation-prop",
+          type: "relation",
+          relation: relationValues(25),
+        },
+      }),
+      retrievePages: [{
+        results: titleItems(30),
+        has_more: false,
+        next_cursor: null,
+      }],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const response = parseToolJson<ReadPageResponse>(
+        await client.callTool({ name: "read_page", arguments: { page_id: "page-1" } }),
+      );
+
+      expect(response.title).toBe("x".repeat(30));
+      expect(notion.pages.properties.retrieve).toHaveBeenCalledTimes(1);
+      expect(notion.pages.properties.retrieve).toHaveBeenCalledWith({
+        page_id: "page-1",
+        property_id: "title-prop",
+      });
+    } finally {
+      await close();
+    }
+  });
+
+  it("fetches a 300-item title with max_property_items set to 0", async () => {
+    const notion = makeNotionStub({
+      page: makePage(25),
+      retrievePages: [
+        {
+          results: titleItems(100),
+          has_more: true,
+          next_cursor: "c1",
+        },
+        {
+          results: titleItems(100),
+          has_more: true,
+          next_cursor: "c2",
+        },
+        {
+          results: titleItems(100),
+          has_more: false,
+          next_cursor: null,
+        },
+      ],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const response = parseToolJson<ReadPageResponse>(
+        await client.callTool({
+          name: "read_page",
+          arguments: { page_id: "page-1", max_property_items: 0 },
+        }),
+      );
+
+      expect(response.title).toHaveLength(300);
+      expect(response.warnings).toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  it("rejects negative max_property_items before retrieving the page", async () => {
+    const notion = makeNotionStub({
+      page: makePage(25),
+      retrievePages: [{
+        results: titleItems(30),
+        has_more: false,
+        next_cursor: null,
+      }],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const response = parseToolJson<ReadPageResponse>(
+        await client.callTool({
+          name: "read_page",
+          arguments: { page_id: "page-1", max_property_items: -1 },
+        }),
+      );
+
+      expect(response.error).toContain("max_property_items");
+      expect(notion.pages.retrieve).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+
+  it("merges truncated_properties with omitted_block_types warnings", async () => {
+    const notion = makeNotionStub({
+      page: makePage(25),
+      retrievePages: [{
+        results: titleItems(75),
+        has_more: true,
+        next_cursor: "c1",
+      }],
+      blocks: [{
+        id: "sync-1",
+        type: "synced_block",
+        synced_block: { synced_from: null },
+        has_children: false,
+      }],
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const response = parseToolJson<ReadPageResponse>(
+        await client.callTool({ name: "read_page", arguments: { page_id: "page-1" } }),
+      );
+
+      expect(response.title).toHaveLength(75);
+      expect(response.warnings?.map((warning) => warning.code)).toEqual([
+        "omitted_block_types",
+        "truncated_properties",
+      ]);
+      expect(response.warnings?.[0]).toEqual({
+        code: "omitted_block_types",
+        blocks: [{ id: "sync-1", type: "synced_block" }],
+      });
+      expect(response.warnings?.[1]).toMatchObject({
+        code: "truncated_properties",
+        properties: [{
+          name: "Name",
+          type: "title",
+          returned_count: 75,
+          cap: 75,
+        }],
+      });
+      expect(response.warnings?.[1].how_to_fetch_all).toContain("max_property_items");
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/relation-roundtrip.test.ts
+++ b/tests/relation-roundtrip.test.ts
@@ -147,7 +147,8 @@ describe("relation property — round-trip through write + read", () => {
         name: "query_database",
         arguments: { database_id: dbId },
       });
-      const rows = JSON.parse(parseToolText(queryResult));
+      const parsed = JSON.parse(parseToolText(queryResult));
+      const rows = parsed.results;
       expect(rows).toHaveLength(1);
       expect(rows[0].Ref).toEqual(["target-id-a"]);
     } finally {
@@ -176,7 +177,8 @@ describe("relation property — round-trip through write + read", () => {
         name: "query_database",
         arguments: { database_id: dbId },
       });
-      const rows = JSON.parse(parseToolText(queryResult));
+      const parsed = JSON.parse(parseToolText(queryResult));
+      const rows = parsed.results;
       expect(rows).toHaveLength(1);
       expect(rows[0].Ref).toEqual(["id-a", "id-b"]);
     } finally {
@@ -200,7 +202,8 @@ describe("relation property — round-trip through write + read", () => {
         name: "query_database",
         arguments: { database_id: dbId },
       });
-      const rows = JSON.parse(parseToolText(queryResult));
+      const parsed = JSON.parse(parseToolText(queryResult));
+      const rows = parsed.results;
       expect(rows).toHaveLength(1);
       expect(rows[0].Ref).toEqual([]);
     } finally {
@@ -230,7 +233,8 @@ describe("relation property — round-trip through write + read", () => {
         name: "query_database",
         arguments: { database_id: dbId },
       });
-      const rows = JSON.parse(parseToolText(queryResult));
+      const parsed = JSON.parse(parseToolText(queryResult));
+      const rows = parsed.results;
       expect(rows).toHaveLength(1);
       expect(rows[0].Ref).toEqual(["id-b"]);
     } finally {


### PR DESCRIPTION
## Summary

Fixes silent truncation on long multi-value page properties (`title`, `rich_text`, `relation`, `people`) at 25 items on `pages.retrieve` / `query_database`. Bumps minor version to v0.5.0.

## The bug

Notion's `GET /v1/pages/{id}` silently truncates `title`, `rich_text`, `relation`, and `people` arrays at 25 items when the full list is longer. `simplifyProperty` and `simplifyEntry` surfaced these truncated values as if they were complete. Silent-data-loss class, highest severity per the 2026-04-20 audit.

## The fix

New `paginatePageProperties` helper walks each page's properties, detects truncated types via a length-equal-to-25 heuristic, and uses `client.pages.properties.retrieve` with `next_cursor` to rehydrate the full array up to a per-property cap.

- Default cap: 75 items per property. Balances LLM context pressure against real-world coverage (95%+ of typical Notion relations and people properties fit under 75).
- `max_property_items: 0` on either tool means unlimited. Callers opt into arbitrary-size property fetches explicitly.
- When the cap fires, the response includes a `truncated_properties` warning with per-property detail (`name`, `type`, `returned_count`, `cap`) and a `how_to_fetch_all` hint at the warning level so agents discover the override mechanism from the response itself, not just the tool description.

Rollup-array pagination is deferred to follow-up task `notion-rollup-array-pagination`; the SDK per-item shape for the inner `rollup.array` is under-specified and needs a live probe.

## Breaking changes

**`query_database` response shape.** Previously returned `Array<SimpleEntry>`. Now returns `{ results: Array<SimpleEntry>, warnings?: Warning[] }` so pagination warnings have a surface. Migration is one line: `rows.map(...)` becomes `rows.results.map(...)`.

`read_page` already returned a structured object with an optional `warnings` array; new `truncated_properties` warnings slot into the existing array without a shape change.

## Version

v0.4.0 to v0.5.0. Breaking changes in minors are the norm for this project pre-1.x. CHANGELOG has a dedicated "Breaking changes" section.

## Test evidence

- 417 tests passing (unit plus mocked integration), 19 skipped, 0 failed. Typecheck and build clean.
- TDD red-then-green for all new code in `tests/paginate-property-value.test.ts`, `tests/paginate-page-properties.test.ts`, `tests/query-database-pagination.test.ts`, `tests/read-page-title-pagination.test.ts`.
- Mutation hand-checks confirmed test sensitivity (swapped relation / people arms and the cap-zero bypass).
- Live e2e against real Notion:
  - 27-item relation returns full 27 with no warning, ~29s wall-clock.
  - 85-item relation with default cap returns 75 items plus `truncated_properties` warning including the `how_to_fetch_all` hint, ~86s wall-clock.
- Teardown hook timeout raised from 60s to 300s to accommodate the larger cleanup load (115 archived per run at Notion rate limits).

## References

- Plan: [`.meta/plans/pr2-long-property-pagination-2026-04-23.md`](.meta/plans/pr2-long-property-pagination-2026-04-23.md)
- Audit anchor: `.meta/audits/notion-api-gap-audit-2026-04-20.md` §1.2 finding 2
- Follow-up tasks filed: `notion-rollup-array-pagination`, `notion-page-title-pagination-secondary-sites`, `notion-query-pagination-concurrency`, `notion-property-pagination-cursor`, `read-page-surface-properties`
- Resolved deferred task: `notion-query-read-warnings` (closed by the response wrap)
