### PR TITLE
fix(bench): use queryDatabase wrapper in scenario 10 assert

### DIFF
--- a/tests/bench/scenarios/10-project-portfolio-rollup/assert.ts
+++ b/tests/bench/scenarios/10-project-portfolio-rollup/assert.ts
@@ -1,4 +1,5 @@
 import type { AssertContext, AssertResult } from "../../harness/types.ts";
+import { queryDatabase } from "../../../../src/notion-client.ts";
 
 export async function assert(ctx: AssertContext): Promise<AssertResult> {
   const blocks = [];
@@ -29,8 +30,8 @@ export async function assert(ctx: AssertContext): Promise<AssertResult> {
     return { passed: false, message: "Tasks database not found under scenario parent" };
   }
 
-  const queryResponse = await ctx.notion.databases.query({ database_id: tasksDbId });
-  const tasksWithRelation = queryResponse.results.filter((row: any) => {
+  const rows = await queryDatabase(ctx.notion, tasksDbId);
+  const tasksWithRelation = rows.filter((row: any) => {
     const projectProp = Object.values(row.properties).find((property: any) => property.type === "relation") as any;
     return projectProp && Array.isArray(projectProp.relation) && projectProp.relation.length > 0;
   });


### PR DESCRIPTION
## Summary

- Scenario 10's `assert.ts` called `ctx.notion.databases.query()`, which does not exist on `@notionhq/client` Client v5.13.x (returns `undefined`). Replaced with the project's `queryDatabase()` wrapper from `src/notion-client.ts`, matching the pattern used by the bench harness runner.

## Evidence

Scenario 10 end-to-end run passes with all 6 claims:

```
Scenario                  Status  Duration  Cost
------------------------------------------------
project-portfolio-rollup  PASS    76.6s     $0.186

Claims:
  databases[0]         pass
  databases[1]         pass
  rows[0]              pass
  rows[1]              pass
  tools_must_be_called pass
  assert.ts            pass  "5 tasks have project relation links"
```

Build clean (`npm run build` exits 0).

## Test plan

- [x] `npm run build` clean
- [x] Scenario 10 full end-to-end pass (all 6 claims green)
- [x] Manifest written: `run-2026-04-24-0c94f02.manifest.json`
