### PR TITLE
ci: add nightly Tier-1 E2E workflow against real Notion

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,44 @@
+# Tier-1 E2E suite against a real Notion workspace.
+# Runs nightly and on manual dispatch — NOT on every PR/push (would be wasteful,
+# slow, and noisy; it creates real pages in a real workspace).
+#
+# NOTE: The C5 people-column test writes a real user ID to a people-type column,
+# which triggers a real-world notification to that user (Iris) on every run.
+# This is intentional coverage of the people-column write path, accepted as a
+# daily notification cost. If this becomes noisy, skip C5 via an env-var gate
+# inside the test itself rather than stripping coverage here.
+name: E2E (Tier-1)
+
+on:
+  schedule:
+    # 06:00 UTC daily (off-peak for Notion API, avoids midnight-boundary edge cases)
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-tier1
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      E2E_ROOT_PAGE_ID: ${{ secrets.E2E_ROOT_PAGE_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Run Tier-1 E2E suite
+        run: npm run test:e2e
+      - name: Sweep stale sandbox pages
+        if: always()
+        run: npm run test:e2e:sweep:apply

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,18 +1,32 @@
 # Tier-1 E2E suite against a real Notion workspace.
-# Runs nightly and on manual dispatch — NOT on every PR/push (would be wasteful,
-# slow, and noisy; it creates real pages in a real workspace).
+# Runs on merges to dev (primary signal), Monday weekly (safety net), and on
+# manual dispatch. NOT on every PR or on push to main — the suite creates real
+# pages in a real workspace, so per-commit fan-out would be wasteful and noisy.
+#
+# Trigger rationale:
+#   - push on dev: catches code-change regressions immediately on merge.
+#     Concurrency group below collapses bursty merges to one run (last push
+#     wins), so a 9-PR day still produces bounded notifications.
+#   - schedule (Mon 06:00 UTC): catches external Notion regressions during
+#     idle weeks when no dev merges have fired. Pinned API version makes
+#     weekly cadence sufficient.
+#   - workflow_dispatch: ad-hoc verification (available after dev→main sync).
 #
 # NOTE: The C5 people-column test writes a real user ID to a people-type column,
 # which triggers a real-world notification to that user (Iris) on every run.
 # This is intentional coverage of the people-column write path, accepted as a
-# daily notification cost. If this becomes noisy, skip C5 via an env-var gate
-# inside the test itself rather than stripping coverage here.
+# bounded notification cost (collapsed on bursty merges, ~1/week minimum from
+# the schedule). If this becomes noisy, skip C5 via an env-var gate inside the
+# test itself rather than stripping coverage here.
 name: E2E (Tier-1)
 
 on:
+  push:
+    branches: [dev]
   schedule:
-    # 06:00 UTC daily (off-peak for Notion API, avoids midnight-boundary edge cases)
-    - cron: '0 6 * * *'
+    # Monday 06:00 UTC — weekly safety-net catches external Notion regressions
+    # during idle weeks when no dev merges have fired the push trigger.
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.meta/research/skills-claw.md
+++ b/.meta/research/skills-claw.md
@@ -1,0 +1,418 @@
+@dimagious/Notion
+
+Work with Notion pages and databases via the official Notion API.
+Updated 1mo ago
+15
+11.6k
+@willykinfoussia/Notion Manager
+
+Notion CLI for creating and managing pages, databases, and blocks.
+Updated 1mo ago
+7
+5.2k
+@byungkyu/Notion
+
+Notion API integration with managed OAuth. Query databases, create and update pages, manage blocks. Use this skill when users want to interact with Notion wo...
+Updated 1mo ago
+8
+8.8k
+@froemic/Notion CLI – Command Line Interface based access to Notion for your agent
+
+Access and manage your Notion workspace via a CLI to search, create, update, and delete pages, databases, blocks, users, and comments with multiple output fo...
+Updated 1mo ago
+2
+2.9k
+@tristanmanchester/Notion API
+
+Manage Notion notes, pages, and data sources with a JSON-first CLI for search, read/export, write/import, append, and move operations. Use when working with Notion, organising notes, moving pages, triaging an inbox, or reading/writing page content.
+Updated 1mo ago
+6
+3.2k
+@timenotspace/Notion API Tools
+
+Generic Notion API CLI (Node) for search, querying data sources (databases), and creating pages. Configure with NOTION_KEY (or ~/.config/notion/api_key).
+Updated 1mo ago
+5
+4.8k
+@robansuini/Notion Sync
+
+Bi-directional sync and management for Notion pages and databases. Use when working with Notion workspaces for collaborative editing, research tracking, proj...
+Updated 1mo ago
+6
+3.8k
+@7revor/Notion 1.0.0
+
+Notion API for creating and managing pages, databases, and blocks.
+Updated 1mo ago
+0
+565
+@dongkukim/Notion API 2026 01 15
+
+Use the Notion API (2026-01-15) to create, move, update, and manage pages, databases, blocks, and apply templates with support for locking and data source qu...
+Updated 1mo ago
+0
+1.3k
+@steipete/Notion
+
+Notion API for creating and managing pages, databases, and blocks.
+Updated 1mo ago
+234
+79.2k
+@moikapy/Notion Enhanced
+
+Integrate with Notion workspaces to read pages, query databases, create entries, and manage content. Perfect for knowledge bases, project tracking, content calendars, CRMs, and collaborative documentation. Works with any Notion page or database you explicitly share with the integration.
+Updated 1mo ago
+4
+2.6k
+@paul-leo/Notion
+
+Notion 集成。搜索页面和数据库，创建/更新/归档页面，读取/追加区块内容，查询数据库。通过 MorphixAI 代理安全访问 Notion API。
+Updated 1mo ago
+0
+355
+@maweis1981/Notion Md
+
+Convert Markdown to Notion blocks with full format support. Handles bold, italic, strikethrough, inline code, headings, lists, tables, callouts, and more.
+Updated 1mo ago
+0
+561
+@mrnsmh/Notion Workspace
+
+Manage Notion workspace — search pages, read content, create pages in databases, append blocks, and list databases. Uses Notion REST API directly via urllib/...
+Updated 23h ago
+0
+466
+@mohdalhashemi98-hue/MH notion
+
+Notion API for creating and managing pages, databases, and blocks.
+Updated 1mo ago
+0
+505
+@tomas-mikula/Notion Manager
+
+Production-ready Notion API client for SaaS workflows. Create/read/update pages, query data sources, append blocks.
+Updated 22h ago
+0
+316
+@nidhov01/Notion
+
+Notion API for creating and managing pages, databases, and blocks.
+Updated 1mo ago
+0
+240
+@ivangdavila/Notion API Integration
+
+Complete Notion API for databases, pages, blocks, users, search, comments, and property types with pagination and error handling.
+Updated 1mo ago
+0
+646
+@qfish/notion-test
+
+Notion API for creating and managing pages, databases, and blocks.
+Updated 1mo ago
+0
+258
+@ewingyangs/notion-clipper-skill
+
+Clip web pages to Notion. Fetches any URL via Chrome CDP, converts HTML to Markdown, then to Notion blocks, and saves to user-specified Notion database or page. Use when user wants to save/clip a webpage to Notion, or mentions "clip to notion", "save page to notion", "网页剪藏到Notion".
+Updated 1mo ago
+1
+950
+@deliverydriver/Notion Workflows
+
+Automate Notion tasks by creating, querying, and updating pages or databases, generating templates, and summarizing content via browser-triggered workflows.
+Updated 22h ago
+0
+263
+@luciorenovato/Notion Tasks Blocks
+
+Manage Notion checklist blocks inside a page (no database required). Use when the user has plain to-do blocks and wants to list tasks, add tasks, and mark ta...
+Updated 1mo ago
+0
+537
+@landercortazarromero/Korta Notion
+
+Notion API for creating and managing pages, databases, and blocks.
+Updated 2w ago
+0
+89
+@ivangdavila/Notion Calendar
+
+Manage Notion calendar databases with date-aware search, page creation, rescheduling, and safe workflows for planning views.
+Updated 23h ago
+0
+364
+@luciorenovato/Notion Mvp
+
+Create and list Notion tasks in a single database via Notion API. Use when the user asks to add tasks, list today tasks, or capture quick todos in Notion fro...
+Updated 1mo ago
+0
+640
+@devxoul/Vibe Notion
+
+Interact with Notion using the unofficial private API - pages, databases, blocks, search, users, comments
+Updated 15m ago
+0
+818
+@byungkyu/Notion MCP
+
+Notion MCP integration with managed authentication. Query databases, create and update pages, manage blocks. Use this skill when users want to interact with...
+Updated 1mo ago
+0
+408
+@lukaizj/Notion Integration
+
+Notion integration - Manage pages, databases, and content in Notion
+Updated 3d ago
+0
+87
+@70asunflower/Notion IM Helper
+
+Sync IM messages to Notion via Notion API. Supports 7 content types, 4 formats, 2 metadata types. Append-only to a single Notion page.
+Updated 21h ago
+1
+254
+@ionepub/Openclaw Notion Api
+
+Notion API 用于创建和管理页面、数据库和块。包含正确的图片、文件上传功能
+Updated 1mo ago
+0
+366
+@jeffreymaomao/Notion Workspace API Tools
+
+Use for tasks that read or modify Notion pages, data sources, or blocks via the Notion API.
+Updated 1d ago
+1
+330
+@hawkvan/Notion Sync Obsidian
+
+自动将Notion文章同步到本地Obsidian目录，支持定时检查、完整内容导出、智能标题提取。
+Updated 1mo ago
+1
+385
+@gevtolev/WeChat to Notion
+
+Save WeChat public account articles to a Notion database. Use when user sends a mp.weixin.qq.com link and wants to save/archive it to Notion. Fetches title,...
+Updated 1mo ago
+0
+299
+@chloepark85/Notion Agent
+
+Notion integration for OpenClaw. Manage pages, databases, and blocks via AI agent.
+Updated 1mo ago
+0
+312
+@smilelight/memory-to-notion
+
+Summarize and archive conversation memories to Notion. Trigger when the user says "summarize memory", "archive conversation", "save memories", "sync memories...
+Updated 1mo ago
+0
+360
+@opoojkk/Wechat Mp To Notion
+
+Fetch WeChat public account (微信公众号) articles from mp.weixin.qq.com links and save them into Notion as structured pages. Use when the user wants to archive a...
+Updated 1mo ago
+0
+90
+@vincentdchan/solid-notion
+
+Manage Notion pages locally as Markdown: pull, edit with JSON patches, write changes, submit edits with rollback, and handle API authentication via solid-not...
+Updated 1mo ago
+0
+265
+@xiangtaoxiao/Notion Time Management Matrix (Eisenhower Matrix)
+
+待办事项管理技能，用于通过 exec 调用 Python 脚本完成指定 Notion 数据库的连接，基于四象限法则进行时间管理，支持待办事项的创建、查询、搜索、状态更新、截止日期修改与分析总结。当用户提出"明天要做"或"最近有什么重要的事"或"25号前解决"或"把任务延期到下周五"等涉及时间管理内容时触发。
+Updated 2w ago
+1
+150
+@evolinkai/Notion
+
+Access, create, update, and automate Notion pages and databases using the official Notion API with Evolink integration.
+Updated 3w ago
+0
+86
+@xinyuqinfeng/b站视频自动生成高质量图文笔记自动截图并上传至Notion笔记
+
+将B站视频字幕转换为带截图的Notion学习笔记。 当用户需要从B站视频提取字幕、分析内容并创建Notion学习笔记时，必须使用此技能。 支持BV号、完整URL输入，自动下载CC字幕，智能处理内容，生成带截图标记的结构化学习笔记。 适用于学习、研究、知识整理等场景。
+Updated 22h ago
+1
+287
+@fr3kstyle/Notion Workspace
+
+Full Notion API skill — query databases, manage pages, append blocks, and search your entire workspace.
+Updated 1mo ago
+0
+122
+@kai-tw/Notion 2025 API Skill
+
+Query, create, and manage Notion databases and pages using the 2025-09-03 API format. Use when: (1) querying or filtering database entries via data_source_id...
+Updated 1mo ago
+0
+297
+@kaising-openclaw1/Cli Notion
+
+Command-line tool to create, list, and retrieve Notion pages using Notion API with JSON input and output.
+Updated 3w ago
+0
+74
+@laurobrcwb/Notion co-worker
+
+An autonomous Notion coworker agent that monitors Gmail for Notion comment mentions (from notify@mail.notion.so), reads the comment to understand what's bein...
+Updated 21h ago
+0
+176
+@zurbrick/Notion Brain
+
+Route high-value content into a Notion workspace with a quality gate, destination mapping, and exact MCP write patterns. ALWAYS trigger when the user says "s...
+Updated 1mo ago
+0
+133
+@xuyangmiemie-beep/Notion 想法点子库 + 里程碑追踪
+
+Notion API for creating and managing pages, databases, and blocks. Also includes 想法点子库（💡）持久化 workflow，当用户说"入库"、"记录这个想法"、"这个先记下来"、"持久化这个"时触发。
+Updated 2w ago
+0
+66
+@otman-ai/Notion
+
+Access and manage Notion workspaces via OAuth to search pages, create and update databases, pages, blocks, and retrieve user info.
+Updated 2w ago
+0
+76
+@molaters/obsidian to notion
+
+Sync Markdown files from Obsidian to a Notion database, preserving rich text, tables, lists, code blocks, callouts, quotes, and managing page updates via ups...
+Updated 1mo ago
+0
+98
+@omermesebuken1/Notion Pipeline
+
+Use when the night-shift agents need to validate Notion env, query a Notion database, create or update pages, or append blocks in the idea-factory databases.
+Updated 3w ago
+0
+102
+@breeze-r/Notion Diary
+
+Write diary entries or short 24-hour reports in Chinese or English, then sync them into Notion using a user-supplied NOTION_API_KEY and the bundled Python sc...
+Updated 3w ago
+0
+124
+@membranedev/Notion
+
+Notion integration. Manage project management and document management data, records, and workflows. Use when the user wants to interact with Notion data.
+Updated 2d ago
+0
+57
+@baixiaodev/Notion Skill Publish
+
+Complete Notion API integration with Python CLI offering auto-pagination, recursive blocks, rate-limit retry, and agent operation strategies for efficient No...
+Updated 1mo ago
+0
+116
+@fental/notion-enhanced-markdown-integration
+
+Notion API for creating and managing pages, databases, blocks and enhanced markdown.
+Updated 3w ago
+1
+71
+@potatosolo/Notion Database Automation
+
+Automate common Notion database operations like batch page creation, data filtering, content generation, and export. Use when you need to automate workflows...
+Updated 1mo ago
+0
+106
+@jolestar/Notion Openapi Skill
+
+Operate Notion Public API through UXC with a curated OpenAPI schema for search, block traversal, page reads, content writes, and data source/database inspect...
+Updated 1mo ago
+0
+96
+@jordancoin/Notion
+
+Notion API for creating and managing pages, databases, blocks, relations, rollups, and multi-workspace profiles via the notioncli CLI tool.
+Updated 56m ago
+0
+907
+@0xarkstar/Clawhub
+
+Notion via notion-cli — a Rust CLI + MCP server for Notion API 2025-09-03+. Three-tier agent integration (read-only default, opt-in runtime writes, opt-in ad...
+Updated 23h ago
+0
+85
+@ivangdavila/Notes (Local, Apple, Notion, Obsidian & more)
+
+Let your agent write notes anywhere: local markdown, Apple Notes, Bear, Obsidian, Notion, Evernote, configurable per note type.
+Updated 58m ago
+3
+3.3k
+@neptunear/Knowledge Capture
+
+Transform conversations and discussions into structured Notion documentation
+Updated 1mo ago
+0
+1.6k
+@lucas-riverbi/Morning Briefing
+
+Provides a personalized morning report with today's reminders, undone Notion tasks, and vault storage summary for daily planning.
+Updated 1h ago
+0
+3.6k
+@nextaltair/Soul In Sapphire
+
+Long-term memory, state tracking, continuity review, and identity-change support for OpenClaw. Use for durable memory writes/search in Notion, emotion/state...
+Updated 55m ago
+0
+1.6k
+@phoenixyy/Getnote Daily Sync
+
+每日自动将 Get笔记（biji.com）当天的录音笔记、会议记录、待办事项汇总后写入 Notion 数据库，生成结构化日报页面。 Use when user says "同步今日 Get笔记", "生成今日日报", "把今天的笔记写到 Notion", "getnote daily sync", or trig...
+Updated 1mo ago
+0
+448
+@nhuanlaptrinh/hocnhanh_n8n
+
+Notion API for creating and managing pages, databases, and blocks.
+Updated 4w ago
+0
+131
+@codeblackhole1024/Expense Tracker v2
+
+Track expenses and income with multi-backend storage (local/Notion/Google Sheet/Supabase). Credentials are encrypted with AES-256-GCM. Use when user wants to...
+Updated 23h ago
+0
+375
+@martc03/Synergy Salon
+
+Manage Synergy salon — appointments, clients, social media, promotions, and website. Notion-powered scheduling and CRM.
+Updated 23h ago
+0
+325
+@martc03/Soil Rich Ops
+
+Manage Soil Rich by John — website updates, blog/social content, ISDA compliance, orders, FFA programs. Notion-powered.
+Updated 23h ago
+0
+316
+@kfuras/notipo
+
+Publish blog posts from AI agents to WordPress via Notion. One API call handles page creation, markdown conversion, image uploads, featured image generation,...
+Updated 1w ago
+0
+232
+@nick-tsyen/GitHub Stars Export
+
+Export GitHub starred repositories by category and sync them to a Notion database.
+Updated 21h ago
+0
+171
+@terrycarter1985/Session Log Analyzer
+
+Analyze agent session logs and generate PDF reports with Notion sync
+Updated 2w ago
+0
+70
+@nissan/Insight Engine
+
+Logs/metrics → Python statistics → LLM interpretation → Notion reports. Use when: generating daily/weekly/monthly operational insights from AI system logs, p...
+Updat


### PR DESCRIPTION
## Summary

Adds `.github/workflows/e2e.yml` — a new GitHub Actions workflow that runs the Tier-1 E2E suite (`tests/e2e/live-mcp.test.ts`, 31 tests against a real Notion workspace) on merges to `dev`, a weekly Monday cron, and via manual dispatch. Additive only; no existing workflows are touched.

## Post-merge verification

Merging this PR fires the first run automatically via the push-on-dev trigger — that's the runtime evidence gate. Watch it with:

```bash
gh run list --workflow=e2e.yml --repo Grey-Iris/easy-notion-mcp
gh run watch <run-id> --repo Grey-Iris/easy-notion-mcp
```

Expected outcome: green conclusion in ~3-5 minutes. Scenario C5 will notify Iris (intentional coverage of the people-column write path; documented in the workflow header).

If the workflow fails: most likely cause is that the `E2E_ROOT_PAGE_ID` secret value is wrong or the referenced page isn't shared with the Test bot. Verify those first before suspecting the workflow itself.

The `workflow_dispatch` capability becomes available for ad-hoc retriggers after the next `dev → main` sync (that's a structural GitHub Actions constraint — manual dispatch requires the workflow file on the default branch).

## Trigger design

Originally scoped as daily cron + dispatch; swapped to the current shape after talking through the notification-cost tradeoff.

- **`push: branches: [dev]`** — primary signal. Catches code-change regressions immediately on merge. Concurrency group `e2e-tier1` with `cancel-in-progress` collapses bursty merges (e.g. a 9-PR day) to one run, so the C5 notification stays bounded.
- **`schedule: cron '0 6 * * 1'`** — Monday 06:00 UTC safety net. Catches external Notion regressions during idle weeks when no dev merges have fired. Weekly cadence is sufficient given the pinned Notion API version.
- **`workflow_dispatch`** — retained for ad-hoc manual verification after `dev → main` sync.
- **Not on PR or push-to-main** — the suite creates real pages in a real workspace; per-commit fan-out would be wasteful and noisy.

## Other design decisions

- **Concurrency:** `group: e2e-tier1`, `cancel-in-progress: true`. Prevents overlapping runs from racing on shared workspace state and collapses bursty merges.
- **Node 20 only**, single job, no matrix. One version is sufficient for E2E; the existing `ci.yml` retains Node 18 + 20 for unit/build coverage.
- **Sweeper:** `npm run test:e2e:sweep:apply` runs with `if: always()` so orphan sandbox pages get archived even when tests fail.
- **People-column notification (C5 test):** The `people schema + value write` test writes a real user ID to a people-type column, which notifies Iris on each run. Accepted as intentional coverage, now bounded by concurrency (merge bursts collapse) and minimum ~1/week from the schedule. Documented in the workflow header.
- **Timeout:** 30 minutes. Generous for a 31-test suite that hits real Notion.

## Secrets required

- `NOTION_TOKEN` (provisioned)
- `E2E_ROOT_PAGE_ID` (provisioned 2026-04-24)

## Test plan

- [x] Workflow YAML parses cleanly
- [x] No modifications to `.github/workflows/ci.yml` or `.github/workflows/release.yml`
- [x] Both required secrets present in repo settings
- [ ] Auto-triggered `push` run on merge-to-dev completes green (tracked in tasuku `verify-e2e-workflow-post-dev-main-sync`, now repurposed to cover the new auto-verification flow)
