### PR TITLE
docs: add Discord pointer at end of Setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Authorization: Bearer <your NOTION_MCP_BEARER value>
 
 easy-notion-mcp works with any MCP-compatible client. The server runs via stdio (API token mode) or HTTP (OAuth or API token mode).
 
+If you run into questions during setup, the [Discord community](https://discord.gg/S8cghJSVBU) is a good place to ask. The `#easy-notion-mcp` channel covers setup and design discussion. Bugs go on [GitHub issues](https://github.com/Grey-Iris/easy-notion-mcp/issues).
+
 ![](assets/papercraft-divider.png)
 
 ## Why markdown-first?


### PR DESCRIPTION
## Summary

Adds one contextual sentence at the end of the Setup section pointing readers at Discord for setup questions. The existing Community section near the bottom and the header badge already cover readers who scroll through; this catches readers who hit a snag mid-setup and need to know where to ask. GitHub issues remain the canonical channel for bugs.

The Setup section itself is otherwise untouched.

## Test plan

- [ ] Verify rendered output on github.com after merge (paragraph appears at end of Setup section, before the divider image)
- [ ] [Discord invite link](https://discord.gg/S8cghJSVBU) resolves
- [ ] [GitHub issues link](https://github.com/Grey-Iris/easy-notion-mcp/issues) resolves
- [ ] No layout regression in the Setup section (divider, next heading, surrounding paragraphs render as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
