### PR TITLE
docs: add Discord pointer at end of Setup section (cherry-pick from dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Authorization: Bearer <your NOTION_MCP_BEARER value>
 
 easy-notion-mcp works with any MCP-compatible client. The server runs via stdio (API token mode) or HTTP (OAuth or API token mode).
 
+If you run into questions during setup, the [Discord community](https://discord.gg/S8cghJSVBU) is a good place to ask. The `#easy-notion-mcp` channel covers setup and design discussion. Bugs go on [GitHub issues](https://github.com/Grey-Iris/easy-notion-mcp/issues).
+
 ![](assets/papercraft-divider.png)
 
 ## Why markdown-first?


### PR DESCRIPTION
## Summary

Cherry-pick of [#46](https://github.com/Grey-Iris/easy-notion-mcp/pull/46) (which landed on `dev`) onto `main` so the live README on the repo homepage shows the same Setup-section Discord pointer. Single-file change to `README.md`, +2 lines. No code, tests, or package changes.

## Test plan

- [ ] After merge, confirm the new line renders correctly in the Setup section on the GitHub homepage view of `main`
- [ ] Both links resolve: the Discord invite (`discord.gg/S8cghJSVBU`) and the GitHub issues link
- [ ] No layout regression in the Setup section (divider image and "Why markdown-first?" heading still flow correctly underneath)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
