### PR TITLE
Notion AI meeting summaries and transcripts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -187,7 +187,19 @@ function getHeadingLevel(type: string): number {
 }
 
 export type OmittedBlock = { id: string; type: string };
-type FetchContext = { omitted: OmittedBlock[] };
+type ReadOnlyRenderedBlock = {
+  id: string;
+  type: "transcription" | "meeting_notes";
+  transcript_omitted?: boolean;
+};
+type FetchContext = {
+  omitted: OmittedBlock[];
+  renderedReadOnly: ReadOnlyRenderedBlock[];
+  includeTranscript: boolean;
+};
+
+const READ_ONLY_BLOCK_RENDERED_MESSAGE =
+  "Rendered read-only Notion AI meeting notes as ordinary markdown. Round-tripping this markdown replaces the native meeting-notes block with ordinary blocks. Blocks marked transcript_omitted had transcript content available but not included.";
 
 /**
  * Block types that `normalizeBlock` can map to a `NotionBlock`. Must stay in
@@ -200,7 +212,7 @@ export const SUPPORTED_BLOCK_TYPES = new Set<string>([
   "bulleted_list_item", "numbered_list_item", "quote", "callout",
   "equation", "table", "table_row", "column_list", "column", "code",
   "divider", "to_do", "table_of_contents", "bookmark", "embed",
-  "image", "file", "audio", "video",
+  "image", "file", "audio", "video", "transcription", "meeting_notes",
 ]);
 
 /**
@@ -367,6 +379,19 @@ function normalizeBlock(block: any): NotionBlock | null {
           rich_text: block.toggle.rich_text as any,
         },
       };
+    case "transcription":
+    case "meeting_notes": {
+      const payload = block[block.type] ?? {};
+      const title = typeof payload.title === "string"
+        ? payload.title
+        : plainText(Array.isArray(payload.title) ? payload.title : []);
+      return {
+        type: "toggle",
+        toggle: {
+          rich_text: richText(title ? `AI Meeting Notes: ${title}` : "AI Meeting Notes"),
+        },
+      };
+    }
     case "bulleted_list_item":
       return {
         type: "bulleted_list_item",
@@ -536,6 +561,170 @@ function attachChildren(block: NotionBlock, children: NotionBlock[]): void {
   }
 }
 
+function isMeetingNotesType(type: string): type is "transcription" | "meeting_notes" {
+  return type === "transcription" || type === "meeting_notes";
+}
+
+function plainText(items: any[]): string {
+  return items.map((item) => item?.plain_text ?? item?.text?.content ?? "").join("");
+}
+
+function richText(content: string): RichText[] {
+  return content ? [{ type: "text", text: { content } }] : [];
+}
+
+function hasRichTextContent(items: RichText[] | undefined): boolean {
+  return (items ?? []).some((item) => item.text.content.length > 0);
+}
+
+function hasVisibleContent(block: NotionBlock): boolean {
+  switch (block.type) {
+    case "heading_1":
+      return hasRichTextContent(block.heading_1.rich_text);
+    case "heading_2":
+      return hasRichTextContent(block.heading_2.rich_text);
+    case "heading_3":
+      return hasRichTextContent(block.heading_3.rich_text);
+    case "paragraph":
+      return hasRichTextContent(block.paragraph.rich_text);
+    case "toggle":
+      return hasRichTextContent(block.toggle.rich_text);
+    case "bulleted_list_item":
+      return hasRichTextContent(block.bulleted_list_item.rich_text);
+    case "numbered_list_item":
+      return hasRichTextContent(block.numbered_list_item.rich_text);
+    case "quote":
+      return hasRichTextContent(block.quote.rich_text);
+    case "callout":
+      return hasRichTextContent(block.callout.rich_text);
+    case "code":
+      return hasRichTextContent(block.code.rich_text);
+    case "equation":
+      return block.equation.expression.length > 0;
+    case "table":
+      return block.table.children.length > 0;
+    case "table_row":
+      return block.table_row.cells.some((cell) => hasRichTextContent(cell));
+    case "column_list":
+      return block.column_list.children.length > 0;
+    case "column":
+      return block.column.children.length > 0;
+    case "divider":
+    case "table_of_contents":
+      return true;
+    case "to_do":
+      return hasRichTextContent(block.to_do.rich_text);
+    case "bookmark":
+      return block.bookmark.url.length > 0;
+    case "embed":
+      return block.embed.url.length > 0;
+    case "image":
+      return true;
+    case "file":
+      return true;
+    case "audio":
+      return true;
+    case "video":
+      return true;
+  }
+}
+
+function sectionHeading(title: string): NotionBlock {
+  return { type: "heading_2", heading_2: { rich_text: richText(title), is_toggleable: false } };
+}
+
+function canAttachChildren(block: NotionBlock): boolean {
+  return block.type === "bulleted_list_item" ||
+    block.type === "numbered_list_item" ||
+    block.type === "toggle" ||
+    block.type === "heading_1" ||
+    block.type === "heading_2" ||
+    block.type === "heading_3" ||
+    block.type === "table" ||
+    block.type === "column_list" ||
+    block.type === "column";
+}
+
+async function fetchSectionBlocks(
+  client: ReturnType<typeof createNotionClient>,
+  sectionBlockId: string,
+  ctx: FetchContext,
+): Promise<NotionBlock[]> {
+  const rawRoot = await retrieveBlock(client, sectionBlockId) as any;
+  const descendants = await fetchBlocksRecursive(client, sectionBlockId, ctx);
+
+  if (isMeetingNotesType(rawRoot.type)) {
+    return descendants;
+  }
+
+  const normalizedRoot = normalizeBlock(rawRoot);
+  if (normalizedRoot && hasVisibleContent(normalizedRoot)) {
+    if (descendants.length > 0 && canAttachChildren(normalizedRoot)) {
+      attachChildren(normalizedRoot, descendants);
+      return [normalizedRoot];
+    }
+    return [normalizedRoot, ...descendants];
+  }
+  if (!normalizedRoot && !SUPPORTED_BLOCK_TYPES.has(rawRoot.type)) {
+    ctx.omitted.push({ id: rawRoot.id, type: rawRoot.type });
+  }
+
+  return descendants;
+}
+
+async function hydrateMeetingNotesBlock(
+  client: ReturnType<typeof createNotionClient>,
+  raw: any,
+  normalized: NotionBlock,
+  ctx: FetchContext,
+): Promise<boolean> {
+  if (!isMeetingNotesType(raw.type)) {
+    return false;
+  }
+
+  const payload = raw[raw.type] ?? {};
+  const pointers = payload.children ?? {};
+  const summaryBlockId = typeof pointers.summary_block_id === "string" ? pointers.summary_block_id : undefined;
+  const notesBlockId = typeof pointers.notes_block_id === "string" ? pointers.notes_block_id : undefined;
+  const transcriptBlockId = typeof pointers.transcript_block_id === "string" ? pointers.transcript_block_id : undefined;
+  const hasSectionPointers = Boolean(summaryBlockId || notesBlockId || transcriptBlockId);
+  const transcriptOmitted = Boolean(transcriptBlockId && !ctx.includeTranscript) ||
+    Boolean(!hasSectionPointers && raw.has_children && !ctx.includeTranscript);
+  const children: NotionBlock[] = [];
+
+  if (typeof payload.status === "string" && payload.status.length > 0) {
+    children.push({ type: "paragraph", paragraph: { rich_text: richText(`Status: ${payload.status}`) } });
+  }
+
+  const appendSection = async (title: string, sectionBlockId: string | undefined) => {
+    if (!sectionBlockId) {
+      return;
+    }
+    children.push(sectionHeading(title));
+    children.push(...await fetchSectionBlocks(client, sectionBlockId, ctx));
+  };
+
+  if (hasSectionPointers) {
+    await appendSection("Summary", summaryBlockId);
+    await appendSection("Notes", notesBlockId);
+    if (ctx.includeTranscript) {
+      await appendSection("Transcript", transcriptBlockId);
+    }
+  } else if (raw.has_children && ctx.includeTranscript) {
+    children.push(...await fetchBlocksRecursive(client, raw.id, ctx));
+  }
+
+  if (children.length > 0) {
+    attachChildren(normalized, children);
+  }
+  ctx.renderedReadOnly.push({
+    id: raw.id,
+    type: raw.type,
+    ...(transcriptOmitted ? { transcript_omitted: true } : {}),
+  });
+  return true;
+}
+
 async function fetchBlocksRecursive(
   client: ReturnType<typeof createNotionClient>,
   blockId: string,
@@ -553,7 +742,11 @@ async function fetchBlocksRecursive(
       continue;
     }
 
-    if (raw.has_children) {
+    const hydratedMeetingNotes = ctx
+      ? await hydrateMeetingNotesBlock(client, raw, normalized, ctx)
+      : false;
+
+    if (!hydratedMeetingNotes && raw.has_children) {
       const children = await fetchBlocksRecursive(client, raw.id, ctx);
       if (children.length > 0) {
         attachChildren(normalized, children);
@@ -598,7 +791,11 @@ async function fetchBlocksWithLimit(
         continue;
       }
 
-      if (raw.has_children) {
+      const hydratedMeetingNotes = ctx
+        ? await hydrateMeetingNotesBlock(client, raw, normalized, ctx)
+        : false;
+
+      if (!hydratedMeetingNotes && raw.has_children) {
         const children = await fetchBlocksRecursive(client, raw.id, ctx);
         if (children.length > 0) {
           attachChildren(normalized, children);
@@ -811,7 +1008,7 @@ To delete a block, pass \`archived: true\` instead of \`markdown\`. Exactly one 
   },
   {
     name: "read_page",
-    description: `Read a page and return its metadata plus markdown content. Recursively fetches nested blocks. Output uses the same conventions as input: toggles as +++ blocks, columns as ::: blocks, callouts as > [!NOTE], tables as | pipes |. If the page contains block types this server does not yet represent in markdown (e.g. synced_block, child_database, link_to_page), those blocks are omitted from the markdown AND listed in a \`warnings\` field with their ids and types. Do NOT round-trip the markdown back through replace_content when warnings are present — the omitted blocks will be deleted from the page.
+    description: `Read a page and return its metadata plus markdown content. Recursively fetches nested blocks. Output uses the same conventions as input: toggles as +++ blocks, columns as ::: blocks, callouts as > [!NOTE], tables as | pipes |. Notion AI meeting notes are rendered as ordinary toggle/heading/paragraph markdown; summaries and notes are included by default, and transcripts are included only with include_transcript: true. If the page contains block types this server does not yet represent in markdown (e.g. synced_block, child_database, link_to_page), those blocks are omitted from the markdown AND listed in a \`warnings\` field with code \`omitted_block_types\`; do NOT round-trip the markdown back through replace_content when that warning is present because omitted blocks will be deleted from the page. A \`read_only_block_rendered\` warning means selected meeting-notes content is represented, but round-tripping replaces the native read-only Notion AI meeting-notes block with ordinary blocks; blocks marked transcript_omitted had transcript content available but not included.
 
 Long titles: when a page title exceeds 25 rich_text segments (uncommon in practice), the response paginates the title up to max_property_items (default 75). If the cap is hit, the response includes a truncated_properties warning with a how_to_fetch_all hint. Call again with max_property_items: 0 for unlimited or with a larger cap number.`,
     inputSchema: {
@@ -831,13 +1028,17 @@ Long titles: when a page title exceeds 25 rich_text segments (uncommon in practi
           description:
             "Max rich_text segments returned when a page title exceeds 25 segments (uncommon in practice). Default 75. Set to 0 for unlimited. Negative values rejected. When the cap is hit, the response includes a truncated_properties warning with a how_to_fetch_all hint.",
         },
+        include_transcript: {
+          type: "boolean",
+          description: "Include Notion AI meeting-notes transcript sections. Default false; summaries and notes are included when available.",
+        },
       },
       required: ["page_id"],
     },
   },
   {
     name: "duplicate_page",
-    description: `Duplicate a page. Reads all blocks from the source and creates a new page with the same content that this server can represent. If the source contains block types this server does not yet support (e.g. child_page subpages, synced_block, child_database, link_to_page), those are omitted from the duplicate AND listed in a \`warnings\` field. Deep-duplication of subpages is not yet supported.`,
+    description: `Duplicate a page. Reads all blocks from the source and creates a new page with the same content that this server can represent. If the source contains block types this server does not yet support (e.g. child_page subpages, synced_block, child_database, link_to_page), those are omitted from the duplicate AND listed in a \`warnings\` field with code \`omitted_block_types\`. Read-only Notion AI meeting notes are duplicated as ordinary toggle/heading/paragraph blocks for summary and notes content, without transcripts by default; \`read_only_block_rendered\` warns that the native meeting-notes block identity is not preserved. Deep-duplication of subpages is not yet supported.`,
     inputSchema: {
       type: "object",
       properties: {
@@ -1517,11 +1718,12 @@ export function createServer(
         }
         case "read_page": {
           const notion = notionClientFactory();
-          const { page_id, include_metadata, max_blocks, max_property_items } = args as {
+          const { page_id, include_metadata, max_blocks, max_property_items, include_transcript } = args as {
             page_id: string;
             include_metadata?: boolean;
             max_blocks?: number;
             max_property_items?: unknown;
+            include_transcript?: boolean;
           };
           const cap = max_property_items === undefined ? 75 : max_property_items;
           if (
@@ -1543,7 +1745,11 @@ export function createServer(
 
           let blocks: NotionBlock[];
           let hasMore = false;
-          const ctx: FetchContext = { omitted: [] };
+          const ctx: FetchContext = {
+            omitted: [],
+            renderedReadOnly: [],
+            includeTranscript: include_transcript === true,
+          };
 
           if (max_blocks !== undefined && max_blocks > 0) {
             const result = await fetchBlocksWithLimit(notion, page_id, max_blocks, ctx);
@@ -1567,6 +1773,13 @@ export function createServer(
           const warnings: unknown[] = [];
           if (ctx.omitted.length > 0) {
             warnings.push({ code: "omitted_block_types", blocks: ctx.omitted });
+          }
+          if (ctx.renderedReadOnly.length > 0) {
+            warnings.push({
+              code: "read_only_block_rendered",
+              blocks: ctx.renderedReadOnly,
+              message: READ_ONLY_BLOCK_RENDERED_MESSAGE,
+            });
           }
           if (propertyWarnings.length > 0) {
             warnings.push({
@@ -1602,7 +1815,7 @@ export function createServer(
           const explicitParent = parent_page_id ?? sourcePage.parent?.page_id;
           const parent = await resolveParent(notion, explicitParent);
 
-          const ctx: FetchContext = { omitted: [] };
+          const ctx: FetchContext = { omitted: [], renderedReadOnly: [], includeTranscript: false };
           const sourceBlocks = await fetchBlocksRecursive(notion, page_id, ctx);
           const sourceIcon =
             sourcePage.icon?.type === "emoji" ? sourcePage.icon.emoji : undefined;
@@ -1617,8 +1830,19 @@ export function createServer(
           if (parent.type === "workspace") {
             response.note = "Created as a private workspace page. Use move_page to relocate.";
           }
+          const warnings: unknown[] = [];
           if (ctx.omitted.length > 0) {
-            response.warnings = [{ code: "omitted_block_types", blocks: ctx.omitted }];
+            warnings.push({ code: "omitted_block_types", blocks: ctx.omitted });
+          }
+          if (ctx.renderedReadOnly.length > 0) {
+            warnings.push({
+              code: "read_only_block_rendered",
+              blocks: ctx.renderedReadOnly,
+              message: READ_ONLY_BLOCK_RENDERED_MESSAGE,
+            });
+          }
+          if (warnings.length > 0) {
+            response.warnings = warnings;
           }
           return textResponse(response);
         }

--- a/tests/block-warnings.test.ts
+++ b/tests/block-warnings.test.ts
@@ -17,7 +17,18 @@ function parseToolText(result: { content?: Array<{ type: string; text?: string }
  * Build a mock `notion` client whose `blocks.children.list` walks a tree map
  * keyed by block_id. Every other SDK surface is a stub.
  */
-function makeNotion(tree: Record<string, Raw[]>, page: Record<string, any> = {}) {
+function makeNotion(
+  tree: Record<string, Raw[]>,
+  page: Record<string, any> = {},
+  blocks: Record<string, Raw> = {},
+) {
+  const byId: Record<string, Raw> = { ...blocks };
+  for (const rawBlocks of Object.values(tree)) {
+    for (const raw of rawBlocks) {
+      byId[raw.id] = raw;
+    }
+  }
+
   return {
     databases: { retrieve: vi.fn(), create: vi.fn() },
     dataSources: { retrieve: vi.fn() },
@@ -45,6 +56,11 @@ function makeNotion(tree: Record<string, Raw[]>, page: Record<string, any> = {})
         })),
         append: vi.fn(),
       },
+      retrieve: vi.fn(async ({ block_id }: any) => {
+        const block = byId[block_id];
+        if (!block) throw new Error(`missing mock block ${block_id}`);
+        return block;
+      }),
       delete: vi.fn(),
     },
     users: { list: vi.fn(), me: vi.fn() },
@@ -72,8 +88,33 @@ async function connect(notion: any) {
 
 // --- raw-block builders ----------------------------------------------------
 
+function rt(content: string) {
+  return [{ type: "text", text: { content }, plain_text: content }];
+}
 function para(id: string): Raw {
   return { id, type: "paragraph", paragraph: { rich_text: [] }, has_children: false };
+}
+function paraText(id: string, content: string, has_children = false): Raw {
+  return { id, type: "paragraph", paragraph: { rich_text: rt(content) }, has_children };
+}
+function toggleText(id: string, content: string, has_children = false): Raw {
+  return { id, type: "toggle", toggle: { rich_text: rt(content) }, has_children };
+}
+function transcription(id: string, children: Record<string, string | undefined>, has_children = false): Raw {
+  return {
+    id,
+    type: "transcription",
+    transcription: { title: rt("Team Sync"), status: "notes_ready", children },
+    has_children,
+  };
+}
+function meetingNotes(id: string, children: Record<string, string | undefined>, has_children = false): Raw {
+  return {
+    id,
+    type: "meeting_notes",
+    meeting_notes: { title: rt("Planning"), status: "notes_ready", children },
+    has_children,
+  };
 }
 function heading1(id: string): Raw {
   return { id, type: "heading_1", heading_1: { rich_text: [] }, has_children: false };
@@ -251,15 +292,297 @@ describe("Block-warnings on read_page and duplicate_page (G-3b)", () => {
     }
   });
 
-  it("G3b-9: read_page description documents the new warnings contract and round-trip caveat", async () => {
+  it("read_page renders a raw transcription block summary as a synthetic toggle", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-summary": [transcription("mn-1", { summary_block_id: "summary-root" })],
+      "summary-root": [paraText("summary-child", "Summary child")],
+    };
+    const { client, close } = await connect(makeNotion(tree, {}, {
+      "summary-root": paraText("summary-root", "Summary root"),
+    }));
+    try {
+      const result = await client.callTool({ name: "read_page", arguments: { page_id: "page-mn-summary" } });
+      const response = extractResponse(parseToolText(result));
+      expect(response.markdown).toContain("+++ AI Meeting Notes: Team Sync");
+      expect(response.markdown).toContain("Status: notes_ready");
+      expect(response.markdown).toContain("## Summary");
+      expect(response.markdown).toContain("Summary root");
+      expect(response.markdown).toContain("Summary child");
+      expect(response.warnings).toEqual([
+        {
+          code: "read_only_block_rendered",
+          blocks: [{ id: "mn-1", type: "transcription" }],
+          message: expect.stringContaining("read-only Notion AI meeting notes"),
+        },
+      ]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("read_page renders a raw meeting_notes block notes section as a synthetic toggle", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-notes": [meetingNotes("mn-2", { notes_block_id: "notes-root" })],
+      "notes-root": [paraText("notes-child", "Notes child")],
+    };
+    const { client, close } = await connect(makeNotion(tree, {}, {
+      "notes-root": paraText("notes-root", "Notes root"),
+    }));
+    try {
+      const result = await client.callTool({ name: "read_page", arguments: { page_id: "page-mn-notes" } });
+      const response = extractResponse(parseToolText(result));
+      expect(response.markdown).toContain("+++ AI Meeting Notes: Planning");
+      expect(response.markdown).toContain("## Notes");
+      expect(response.markdown).toContain("Notes root");
+      expect(response.markdown).toContain("Notes child");
+      expect(response.warnings[0].blocks).toEqual([{ id: "mn-2", type: "meeting_notes" }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("read_page omits Transcript by default when a transcript pointer exists", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-transcript-default": [transcription("mn-3", {
+        summary_block_id: "summary-root",
+        transcript_block_id: "transcript-root",
+      })],
+      "summary-root": [paraText("summary-child", "Summary text")],
+      "transcript-root": [paraText("transcript-child", "Transcript text")],
+    };
+    const { client, close } = await connect(makeNotion(tree, {}, {
+      "summary-root": paraText("summary-root", ""),
+      "transcript-root": paraText("transcript-root", "Transcript root"),
+    }));
+    try {
+      const result = await client.callTool({ name: "read_page", arguments: { page_id: "page-mn-transcript-default" } });
+      const response = extractResponse(parseToolText(result));
+      expect(response.markdown).toContain("## Summary");
+      expect(response.markdown).not.toContain("## Transcript");
+      expect(response.markdown).not.toContain("Transcript text");
+      expect(response.markdown).not.toContain("Transcript root");
+      expect(response.warnings[0].blocks).toEqual([
+        { id: "mn-3", type: "transcription", transcript_omitted: true },
+      ]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("read_page includes Transcript when include_transcript is true", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-transcript": [transcription("mn-4", { transcript_block_id: "transcript-root" })],
+      "transcript-root": [paraText("transcript-child", "Transcript child")],
+    };
+    const { client, close } = await connect(makeNotion(tree, {}, {
+      "transcript-root": paraText("transcript-root", "Transcript root"),
+    }));
+    try {
+      const result = await client.callTool({
+        name: "read_page",
+        arguments: { page_id: "page-mn-transcript", include_transcript: true },
+      });
+      const response = extractResponse(parseToolText(result));
+      expect(response.markdown).toContain("## Transcript");
+      expect(response.markdown).toContain("Transcript root");
+      expect(response.markdown).toContain("Transcript child");
+    } finally {
+      await close();
+    }
+  });
+
+  it("read_page does not render pointerless meeting-note direct children by default", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-direct-default": [transcription("mn-5", {}, true)],
+      "mn-5": [paraText("direct-child", "Direct child")],
+    };
+    const { client, close } = await connect(makeNotion(tree));
+    try {
+      const result = await client.callTool({ name: "read_page", arguments: { page_id: "page-mn-direct-default" } });
+      const response = extractResponse(parseToolText(result));
+      expect(response.markdown).toContain("+++ AI Meeting Notes: Team Sync");
+      expect(response.markdown).not.toContain("Direct child");
+      expect(response.warnings[0]).toMatchObject({
+        code: "read_only_block_rendered",
+        blocks: [{ id: "mn-5", type: "transcription", transcript_omitted: true }],
+      });
+    } finally {
+      await close();
+    }
+  });
+
+  it("read_page falls back to direct children when pointerless meeting notes are read with include_transcript", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-direct": [transcription("mn-5b", {}, true)],
+      "mn-5b": [paraText("direct-child", "Direct child")],
+    };
+    const { client, close } = await connect(makeNotion(tree));
+    try {
+      const result = await client.callTool({
+        name: "read_page",
+        arguments: { page_id: "page-mn-direct", include_transcript: true },
+      });
+      const response = extractResponse(parseToolText(result));
+      expect(response.markdown).toContain("Direct child");
+      expect(response.warnings[0].blocks).toEqual([{ id: "mn-5b", type: "transcription" }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("read_page preserves supported section-root container hierarchy", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-section-hierarchy": [transcription("mn-6a", { summary_block_id: "summary-toggle" })],
+      "summary-toggle": [paraText("summary-child", "Nested summary")],
+    };
+    const { client, close } = await connect(makeNotion(tree, {}, {
+      "summary-toggle": toggleText("summary-toggle", "Root toggle", true),
+    }));
+    try {
+      const result = await client.callTool({ name: "read_page", arguments: { page_id: "page-mn-section-hierarchy" } });
+      const response = extractResponse(parseToolText(result));
+      expect(response.markdown).toContain("## Summary\n\n+++ Root toggle\nNested summary\n+++");
+    } finally {
+      await close();
+    }
+  });
+
+  it("read_page uses section pointers instead of also recursing into the meeting-note block", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-no-dup": [transcription("mn-6", { summary_block_id: "summary-root" }, true)],
+      "mn-6": [paraText("direct-child", "Should not appear")],
+      "summary-root": [paraText("summary-child", "Pointer child")],
+    };
+    const { client, close } = await connect(makeNotion(tree, {}, {
+      "summary-root": paraText("summary-root", "Pointer root"),
+    }));
+    try {
+      const result = await client.callTool({ name: "read_page", arguments: { page_id: "page-mn-no-dup" } });
+      const response = extractResponse(parseToolText(result));
+      expect(response.markdown).toContain("Pointer root");
+      expect(response.markdown).toContain("Pointer child");
+      expect(response.markdown).not.toContain("Should not appear");
+    } finally {
+      await close();
+    }
+  });
+
+  it("read_page returns read_only_block_rendered plus omitted_block_types for mixed meeting notes and unsupported blocks", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-mixed": [transcription("mn-7", { summary_block_id: "summary-root" }), syncedBlock("sync-1")],
+      "summary-root": [paraText("summary-child", "Summary")],
+    };
+    const { client, close } = await connect(makeNotion(tree, {}, {
+      "summary-root": paraText("summary-root", ""),
+    }));
+    try {
+      const result = await client.callTool({ name: "read_page", arguments: { page_id: "page-mn-mixed" } });
+      const response = extractResponse(parseToolText(result));
+      expect(response.warnings.map((warning: any) => warning.code)).toEqual([
+        "omitted_block_types",
+        "read_only_block_rendered",
+      ]);
+      expect(response.warnings[0].blocks).toEqual([{ id: "sync-1", type: "synced_block" }]);
+      expect(response.warnings[1].blocks).toEqual([{ id: "mn-7", type: "transcription" }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("max_blocks caps top-level traversal but renders selected sections for an included meeting-notes block", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-max": [para("b1"), transcription("mn-8", { notes_block_id: "notes-root" }), syncedBlock("sync-3")],
+      "notes-root": [paraText("notes-child", "Notes inside cap")],
+    };
+    const { client, close } = await connect(makeNotion(tree, {}, {
+      "notes-root": paraText("notes-root", ""),
+    }));
+    try {
+      const result = await client.callTool({
+        name: "read_page",
+        arguments: { page_id: "page-mn-max", max_blocks: 2 },
+      });
+      const response = extractResponse(parseToolText(result));
+      expect(response.has_more).toBe(true);
+      expect(response.markdown).toContain("## Notes");
+      expect(response.markdown).toContain("Notes inside cap");
+      expect(response.warnings).toHaveLength(1);
+      expect(response.warnings[0].code).toBe("read_only_block_rendered");
+    } finally {
+      await close();
+    }
+  });
+
+  it("duplicate_page copies meeting-notes summary/notes as ordinary blocks, omits transcript by default, and warns", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-dup": [meetingNotes("mn-9", {
+        summary_block_id: "summary-root",
+        notes_block_id: "notes-root",
+        transcript_block_id: "transcript-root",
+      })],
+      "summary-root": [paraText("summary-child", "Dup summary")],
+      "notes-root": [paraText("notes-child", "Dup notes")],
+      "transcript-root": [paraText("transcript-child", "Dup transcript")],
+    };
+    const notion = makeNotion(tree, {}, {
+      "summary-root": paraText("summary-root", ""),
+      "notes-root": paraText("notes-root", ""),
+      "transcript-root": paraText("transcript-root", ""),
+    });
+    const { client, close } = await connect(notion);
+    try {
+      const result = await client.callTool({ name: "duplicate_page", arguments: { page_id: "page-mn-dup" } });
+      const response = extractResponse(parseToolText(result));
+      expect(response.warnings).toEqual([
+        {
+          code: "read_only_block_rendered",
+          blocks: [{ id: "mn-9", type: "meeting_notes", transcript_omitted: true }],
+          message: expect.stringContaining("read-only Notion AI meeting notes"),
+        },
+      ]);
+      const createCall = notion.pages.create.mock.calls[0][0];
+      const markdownSource = JSON.stringify(createCall.children);
+      expect(markdownSource).toContain("Dup summary");
+      expect(markdownSource).toContain("Dup notes");
+      expect(markdownSource).not.toContain("Dup transcript");
+      expect((createCall.children ?? []).map((block: any) => block.type)).toEqual(["toggle"]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("duplicate_page returns read_only_block_rendered plus omitted_block_types for mixed meeting notes and unsupported blocks", async () => {
+    const tree: Record<string, Raw[]> = {
+      "page-mn-dup-mixed": [meetingNotes("mn-10", { notes_block_id: "notes-root" }), childPage("cp-1")],
+      "notes-root": [paraText("notes-child", "Dup notes")],
+    };
+    const { client, close } = await connect(makeNotion(tree, {}, {
+      "notes-root": paraText("notes-root", ""),
+    }));
+    try {
+      const result = await client.callTool({ name: "duplicate_page", arguments: { page_id: "page-mn-dup-mixed" } });
+      const response = extractResponse(parseToolText(result));
+      expect(response.warnings.map((warning: any) => warning.code)).toEqual([
+        "omitted_block_types",
+        "read_only_block_rendered",
+      ]);
+      expect(response.warnings[0].blocks).toEqual([{ id: "cp-1", type: "child_page" }]);
+      expect(response.warnings[1].blocks).toEqual([{ id: "mn-10", type: "meeting_notes" }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("G3b-9: read_page description documents the warnings contract, include_transcript, and round-trip caveat", async () => {
     const { client, close } = await connect(makeNotion({}));
     try {
       const { tools } = await client.listTools();
       const readPage = tools.find((t) => t.name === "read_page");
       const description = readPage!.description ?? "";
       expect(description).toMatch(/omitted from the markdown/i);
-      expect(description).toMatch(/warnings/i);
-      expect(description).toMatch(/Do NOT round-trip/i);
+      expect(description).toMatch(/include_transcript/i);
+      expect(description).toMatch(/read_only_block_rendered/i);
+      expect(description).toMatch(/do NOT round-trip/i);
     } finally {
       await close();
     }
@@ -272,6 +595,7 @@ describe("Block-warnings on read_page and duplicate_page (G-3b)", () => {
       const duplicatePage = tools.find((t) => t.name === "duplicate_page");
       const description = duplicatePage!.description ?? "";
       expect(description).toMatch(/warnings/i);
+      expect(description).toMatch(/read_only_block_rendered/i);
       expect(description).toMatch(/Deep-duplication/i);
       expect(description).toMatch(/not yet supported/i);
     } finally {
@@ -279,7 +603,7 @@ describe("Block-warnings on read_page and duplicate_page (G-3b)", () => {
     }
   });
 
-  it("G3b-11: SUPPORTED_BLOCK_TYPES drift-invariant — every entry yields no warning when read", async () => {
+  it("G3b-11: SUPPORTED_BLOCK_TYPES drift-invariant — every entry yields no omitted warning when read", async () => {
     // Build a minimal-valid raw block for each supported type. If a maintainer
     // adds a type to SUPPORTED_BLOCK_TYPES without teaching normalizeBlock to
     // handle it, that type will normalize to null and bubble up as a warning.
@@ -308,6 +632,8 @@ describe("Block-warnings on read_page and duplicate_page (G-3b)", () => {
       file: (id) => ({ id, type: "file", file: { type: "external", external: { url: "https://example.com/f.pdf" }, name: "f.pdf" }, has_children: false }),
       audio: (id) => ({ id, type: "audio", audio: { type: "external", external: { url: "https://example.com/a.mp3" } }, has_children: false }),
       video: (id) => ({ id, type: "video", video: { type: "external", external: { url: "https://example.com/v.mp4" } }, has_children: false }),
+      transcription: (id) => transcription(id, {}),
+      meeting_notes: (id) => meetingNotes(id, {}),
     };
     for (const type of SUPPORTED_BLOCK_TYPES) {
       expect(builders[type], `builder missing for supported type '${type}' — add one to this test`).toBeDefined();
@@ -321,7 +647,10 @@ describe("Block-warnings on read_page and duplicate_page (G-3b)", () => {
           arguments: { page_id: "page-invariant" },
         });
         const response = extractResponse(parseToolText(result));
-        expect(response.warnings, `type '${type}' surfaced as omitted — add a normalizeBlock case`).toBeUndefined();
+        const omittedWarnings = (response.warnings ?? []).filter(
+          (warning: any) => warning.code === "omitted_block_types",
+        );
+        expect(omittedWarnings, `type '${type}' surfaced as omitted — add a normalizeBlock case`).toEqual([]);
       } finally {
         await close();
       }


### PR DESCRIPTION
## What this PR does

Adds the ability to fetch Notion AI meeting summaries and optionally transcripts.

## Why

#60 

It would be nice to use this and be able to get the meeting summary blocks as part of my own agent workflows.

## How to test

Test just like any other thing, but pull a page with an AI meeting summary.  You'll see the new block.  Add `include_transcript: true` and you'll get the full transcript.

## Checklist

- [x] Targets `dev` branch
- [x] All tests pass locally (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] New/updated tests for changed behavior
- [x] No new dependencies added
- [x] No changes to CI workflows, package.json deps, or tsconfig.json
- [x] I have read CONTRIBUTING.md

## Files changed rationale

- `src/server.ts`: Adds `read_page.include_transcript`, renders Notion AI meeting-notes/transcription blocks as repo-standard markdown, and emits roundtrip/privacy warnings.
 - `tests/block-warnings.test.ts` — Covers meeting-notes rendering, transcript opt-in/default omission, warning semantics, duplicate behavior, and supported-block drift.
