### PR TITLE
Release v0.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ internal/
 .meta/bench/transcripts/
 .meta/bench/.runner-pids/
 
+# Local working artifacts
+tmp/
+
 # Internal documents (not for public repo)
 audit-report-*.md
 competitor-comparison.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-09
+
 ### Added
 
 - **Notion AI meeting-notes read support.** `read_page`, `read_section`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Notion AI meeting-notes read support.** `read_page`, `read_section`,
+  `read_block`, `read_toggle`, and `duplicate_page` render Notion's
+  read-only AI meeting-notes (and deprecated `transcription`) blocks
+  as a synthetic toggle containing the title, an optional recording
+  timestamp callout, and `## Summary` / `## Notes` heading sections.
+  `read_page` accepts `include_transcript: true` to include transcript
+  sections; the CLI exposes `--include-transcript` on `page read`.
+  A new `read_only_block_rendered` warning is emitted alongside the
+  rendered markdown, with `transcript_omitted` and `sections_unreadable`
+  subfields documenting what was suppressed or failed to fetch.
+  Round-tripping the markdown through `replace_content` replaces these
+  blocks with ordinary blocks; the warning lets agents detect that
+  before writing back.
+
 ## [0.9.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -494,7 +494,9 @@ Yes. Round-trip fidelity is a core design guarantee of easy-notion-mcp, not a si
 
 What you write is what you read back. `read_page` returns the exact same markdown syntax that `create_page` accepts — headings, lists, tables, callouts, toggles, columns, equations, all of it.
 
-When a page contains Notion block types this server does not yet represent, such as `synced_block`, `child_database`, `child_page`, `link_to_page`, or `meeting_notes`, `read_page` includes a `warnings` field with the omitted block IDs and types. Round-tripping that markdown through `replace_content` would delete those blocks, so the warning lets agents avoid unsafe rewrites.
+When a page contains Notion block types this server does not yet represent, such as `synced_block`, `child_database`, `child_page`, or `link_to_page`, `read_page` includes a `warnings` field with code `omitted_block_types` listing the omitted block IDs and types. Round-tripping that markdown through `replace_content` would delete those blocks, so the warning lets agents avoid unsafe rewrites.
+
+Notion AI meeting-notes (and deprecated `transcription`) blocks are rendered as a synthetic toggle containing the title, an optional recording timestamp, and `## Summary` / `## Notes` sections; transcripts are included only with `read_page include_transcript: true`. These render reads emit a `read_only_block_rendered` warning to flag that round-tripping replaces the native meeting block with ordinary blocks.
 
 easy-notion-mcp enables agents to read a page, modify the markdown string, and write it back without losing formatting, structure, or content. No format translation. No block reconstruction. Agents edit Notion pages the same way they edit code — as text.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-notion-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-notion-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-notion-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "mcpName": "io.github.misterwigglesworth/easy-notion",
   "description": "Token-efficient, markdown-first Notion MCP server — agents write markdown, never touch raw Notion JSON",
   "type": "module",

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -44,6 +44,7 @@ import {
   getToggleTitle,
   isToggleableHeading,
   normalizeBlock,
+  READ_ONLY_BLOCK_RENDERED_MESSAGE,
   searchInPage,
   simplifyProperty,
   SUPPORTED_BLOCK_TYPES,
@@ -124,12 +125,12 @@ type NotionOps = {
     page: unknown,
     opts: { maxPropertyItems: number; onlyTypes?: Array<"title" | "rich_text" | "relation" | "people"> },
   ): Promise<{ page: unknown; warnings: unknown[] }>;
-  fetchBlocksRecursive(client: Client, pageId: string, ctx: { omitted: Array<{ id: string; type: string }> }): Promise<unknown[]>;
+  fetchBlocksRecursive(client: Client, pageId: string, ctx: FetchContext): Promise<unknown[]>;
   fetchBlocksWithLimit(
     client: Client,
     pageId: string,
     maxBlocks: number,
-    ctx: { omitted: Array<{ id: string; type: string }> },
+    ctx: FetchContext,
   ): Promise<{ blocks: unknown[]; hasMore: boolean }>;
   processFileUploads(client: Client, markdown: string): Promise<string>;
   appendBlocks(client: Client, pageId: string, blocks: ReturnType<typeof markdownToBlocks>): Promise<unknown[]>;
@@ -251,7 +252,7 @@ function helpText(): string {
     "  user me",
     "  user list",
     "  search <query> [--filter pages|databases]",
-    "  page read <page> [--include-metadata] [--max-blocks <n>] [--max-property-items <n>]",
+    "  page read <page> [--include-metadata] [--include-transcript] [--max-blocks <n>] [--max-property-items <n>]",
     "  page create --title <title> [--parent <page_id>] [--icon <emoji>] [--cover <url>] (--markdown <text>|--markdown-file <path>|--stdin)",
     "  page create-from-file --title <title> --file <path> [--parent <page_id>]",
     "  page duplicate <page_id> [--title <title>] [--parent <page_id>]",
@@ -625,10 +626,19 @@ async function findToggleRecursiveForCli(
   return { block: await visit(pageId), availableTitles };
 }
 
-function omittedBlockWarnings(ctx: FetchContext): unknown[] {
-  return ctx.omitted.length > 0
-    ? [{ code: "omitted_block_types", blocks: ctx.omitted }]
-    : [];
+function readWarnings(ctx: FetchContext): unknown[] {
+  const out: unknown[] = [];
+  if (ctx.omitted.length > 0) {
+    out.push({ code: "omitted_block_types", blocks: ctx.omitted });
+  }
+  if ((ctx.renderedReadOnly ?? []).length > 0) {
+    out.push({
+      code: "read_only_block_rendered",
+      blocks: ctx.renderedReadOnly,
+      message: READ_ONLY_BLOCK_RENDERED_MESSAGE,
+    });
+  }
+  return out;
 }
 
 function targetedBlocksToMarkdown(blocks: any[]): string {
@@ -925,19 +935,17 @@ async function handlePage(args: string[], options: GlobalOptions, io: CliIO, con
     const client = clientFor(resolved, ops);
     const cap = parseNonNegativeInteger(readFlag(args, "--max-property-items"), "--max-property-items") ?? 75;
     const maxBlocks = parseNonNegativeInteger(readFlag(args, "--max-blocks"), "--max-blocks");
+    const includeTranscript = hasFlag(args, "--include-transcript");
     const rawPage = await ops.getPage(client, pageId);
     const { page, warnings: propertyWarnings } = await ops.paginatePageProperties(client, rawPage, {
       maxPropertyItems: cap,
       onlyTypes: ["title"],
     });
-    const ctx: { omitted: Array<{ id: string; type: string }> } = { omitted: [] };
+    const ctx: FetchContext = { omitted: [], renderedReadOnly: [], includeTranscript };
     const blockResult = maxBlocks && maxBlocks > 0
       ? await ops.fetchBlocksWithLimit(client, pageId, maxBlocks, ctx)
       : { blocks: await ops.fetchBlocksRecursive(client, pageId, ctx), hasMore: false };
-    const warnings: unknown[] = [];
-    if (ctx.omitted.length > 0) {
-      warnings.push({ code: "omitted_block_types", blocks: ctx.omitted });
-    }
+    const warnings: unknown[] = [...readWarnings(ctx)];
     if (propertyWarnings.length > 0) {
       warnings.push({
         code: "truncated_properties",
@@ -1029,16 +1037,15 @@ async function handlePage(args: string[], options: GlobalOptions, io: CliIO, con
       resolved.rootPageId,
       "page duplicate",
     );
-    const ctx: { omitted: Array<{ id: string; type: string }> } = { omitted: [] };
+    const ctx: FetchContext = { omitted: [], renderedReadOnly: [], includeTranscript: false };
     const blocks = await ops.fetchBlocksRecursive(client, pageId, ctx);
     const icon = sourcePage.icon?.type === "emoji" ? sourcePage.icon.emoji : undefined;
     const page = await ops.createPage(client, parent, title, blocks as ReturnType<typeof markdownToBlocks>, icon) as any;
+    const warnings = readWarnings(ctx);
     return success({
       ...mapMutationResultPage(page, title),
       source_page_id: pageId,
-      ...(ctx.omitted.length > 0
-        ? { warnings: [{ code: "omitted_block_types", blocks: ctx.omitted }] }
-        : {}),
+      ...(warnings.length > 0 ? { warnings } : {}),
     });
   }
 
@@ -1167,14 +1174,14 @@ async function handleContent(args: string[], options: GlobalOptions, io: CliIO, 
       );
     }
 
-    const ctx: FetchContext = { omitted: [] };
+    const ctx: FetchContext = { omitted: [], renderedReadOnly: [] };
     const blocks = await fetchRawBlocksRecursiveForCli(
       client,
       (allBlocks as any[]).slice(range.headingIndex, range.sectionEnd),
       ctx,
       ops,
     );
-    const warnings = omittedBlockWarnings(ctx);
+    const warnings = readWarnings(ctx);
     return success({
       page_id: pageId,
       heading: getBlockHeadingText(range.headingBlock) ?? heading,
@@ -1206,9 +1213,9 @@ async function handleContent(args: string[], options: GlobalOptions, io: CliIO, 
       );
     }
 
-    const ctx: FetchContext = { omitted: [] };
+    const ctx: FetchContext = { omitted: [], renderedReadOnly: [] };
     const blocks = await fetchRawBlocksRecursiveForCli(client, [found.block], ctx, ops);
-    const warnings = omittedBlockWarnings(ctx);
+    const warnings = readWarnings(ctx);
     return success({
       page_id: pageId,
       title: getToggleTitle(found.block) ?? title,
@@ -1686,7 +1693,7 @@ async function handleBlock(args: string[], options: GlobalOptions, io: CliIO, co
     }
     const resolved = await resolveSelectedProfile(options, io, configDir);
     const client = clientFor(resolved, ops);
-    const ctx: FetchContext = { omitted: [] };
+    const ctx: FetchContext = { omitted: [], renderedReadOnly: [] };
     const { raw, block } = await fetchBlockRecursiveForCli(client, blockId, ctx, ops);
     if (!block) {
       throw new CliError(
@@ -1697,7 +1704,7 @@ async function handleBlock(args: string[], options: GlobalOptions, io: CliIO, co
       );
     }
 
-    const warnings = omittedBlockWarnings(ctx);
+    const warnings = readWarnings(ctx);
     return success({
       id: raw.id ?? blockId,
       type: raw.type ?? (block as any).type,

--- a/src/server.ts
+++ b/src/server.ts
@@ -434,6 +434,21 @@ function richTextPlainText(richText: any[]): string {
   return richText.map((text: any) => text.plain_text ?? text.text?.content ?? "").join("");
 }
 
+function normalizeRichText(items: any[] | undefined): RichText[] {
+  if (!Array.isArray(items)) return [];
+  return items.map((item) => {
+    const content = item?.plain_text ?? item?.text?.content ?? "";
+    const link = item?.text?.link?.url ?? item?.href ?? null;
+    const annotations = item?.annotations;
+    const out: RichText = {
+      type: "text",
+      text: { content, link: link ? { url: link } : null },
+    };
+    if (annotations) out.annotations = annotations;
+    return out;
+  });
+}
+
 function normalizedHeadingText(text: string): string {
   return text.trim().replace(/\s+/g, " ").toLowerCase();
 }
@@ -518,7 +533,19 @@ export function updateSectionPreserveHeadingBody(
 }
 
 export type OmittedBlock = { id: string; type: string };
-export type FetchContext = { omitted: OmittedBlock[] };
+export const READ_ONLY_BLOCK_RENDERED_MESSAGE =
+  "Rendered read-only Notion AI meeting notes as ordinary markdown. Round-tripping this markdown replaces the native meeting-notes block with ordinary blocks. Blocks marked transcript_omitted had transcript content available but not included.";
+export type ReadOnlyRenderedBlock = {
+  id: string;
+  type: "transcription" | "meeting_notes";
+  transcript_omitted?: boolean;
+  sections_unreadable?: Array<{ key: string; block_id: string; code?: string }>;
+};
+export type FetchContext = {
+  omitted: OmittedBlock[];
+  renderedReadOnly?: ReadOnlyRenderedBlock[];
+  includeTranscript?: boolean;
+};
 
 /**
  * Block types that `normalizeBlock` can map to a `NotionBlock`. Must stay in
@@ -531,7 +558,7 @@ export const SUPPORTED_BLOCK_TYPES = new Set<string>([
   "bulleted_list_item", "numbered_list_item", "quote", "callout",
   "equation", "table", "table_row", "column_list", "column", "code",
   "divider", "to_do", "table_of_contents", "bookmark", "embed",
-  "image", "file", "audio", "video",
+  "image", "file", "audio", "video", "transcription", "meeting_notes",
 ]);
 
 /**
@@ -674,50 +701,50 @@ export function normalizeBlock(block: any): NotionBlock | null {
     case "heading_1":
       return {
         type: "heading_1",
-        heading_1: { rich_text: block.heading_1.rich_text as any, is_toggleable: block.heading_1.is_toggleable ?? false },
+        heading_1: { rich_text: normalizeRichText(block.heading_1.rich_text), is_toggleable: block.heading_1.is_toggleable ?? false },
       };
     case "heading_2":
       return {
         type: "heading_2",
-        heading_2: { rich_text: block.heading_2.rich_text as any, is_toggleable: block.heading_2.is_toggleable ?? false },
+        heading_2: { rich_text: normalizeRichText(block.heading_2.rich_text), is_toggleable: block.heading_2.is_toggleable ?? false },
       };
     case "heading_3":
       return {
         type: "heading_3",
-        heading_3: { rich_text: block.heading_3.rich_text as any, is_toggleable: block.heading_3.is_toggleable ?? false },
+        heading_3: { rich_text: normalizeRichText(block.heading_3.rich_text), is_toggleable: block.heading_3.is_toggleable ?? false },
       };
     case "paragraph":
       return {
         type: "paragraph",
-        paragraph: { rich_text: block.paragraph.rich_text as any },
+        paragraph: { rich_text: normalizeRichText(block.paragraph.rich_text) },
       };
     case "toggle":
       return {
         type: "toggle",
         toggle: {
-          rich_text: block.toggle.rich_text as any,
+          rich_text: normalizeRichText(block.toggle.rich_text),
         },
       };
     case "bulleted_list_item":
       return {
         type: "bulleted_list_item",
-        bulleted_list_item: { rich_text: block.bulleted_list_item.rich_text as any },
+        bulleted_list_item: { rich_text: normalizeRichText(block.bulleted_list_item.rich_text) },
       };
     case "numbered_list_item":
       return {
         type: "numbered_list_item",
-        numbered_list_item: { rich_text: block.numbered_list_item.rich_text as any },
+        numbered_list_item: { rich_text: normalizeRichText(block.numbered_list_item.rich_text) },
       };
     case "quote":
       return {
         type: "quote",
-        quote: { rich_text: block.quote.rich_text as any },
+        quote: { rich_text: normalizeRichText(block.quote.rich_text) },
       };
     case "callout":
       return {
         type: "callout",
         callout: {
-          rich_text: block.callout.rich_text as any,
+          rich_text: normalizeRichText(block.callout.rich_text),
           icon: block.callout.icon ?? { type: "emoji", emoji: "\u{1F4A1}" },
         },
       };
@@ -747,7 +774,7 @@ export function normalizeBlock(block: any): NotionBlock | null {
       return {
         type: "table_row",
         table_row: {
-          cells: (block.table_row.cells ?? []).map((cell: any) => cell as RichText[]),
+          cells: (block.table_row.cells ?? []).map((cell: any) => normalizeRichText(cell)),
         },
       };
     case "column_list":
@@ -764,7 +791,7 @@ export function normalizeBlock(block: any): NotionBlock | null {
       return {
         type: "code",
         code: {
-          rich_text: block.code.rich_text as any,
+          rich_text: normalizeRichText(block.code.rich_text),
           language: block.code.language,
         },
       };
@@ -777,7 +804,7 @@ export function normalizeBlock(block: any): NotionBlock | null {
       return {
         type: "to_do",
         to_do: {
-          rich_text: block.to_do.rich_text as any,
+          rich_text: normalizeRichText(block.to_do.rich_text),
           checked: block.to_do.checked,
         },
       };
@@ -827,6 +854,16 @@ export function normalizeBlock(block: any): NotionBlock | null {
       const url = block.video?.type === "external" ? block.video.external.url
         : block.video?.type === "file" ? block.video.file?.url : "";
       return { type: "video", video: { type: "external", external: { url: url ?? "" } } };
+    }
+    case "transcription":
+    case "meeting_notes": {
+      const payload = block[block.type] ?? {};
+      const titlePlain = richTextPlainText(Array.isArray(payload.title) ? payload.title : []);
+      const titleText = titlePlain.length > 0 ? `AI Meeting Notes: ${titlePlain}` : "AI Meeting Notes";
+      return {
+        type: "toggle",
+        toggle: { rich_text: [{ type: "text", text: { content: titleText, link: null } }] },
+      };
     }
     default:
       return null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -272,11 +272,38 @@ Shape:
 \`\`\`json
 {
   "code": "omitted_block_types",
-  "blocks": [{ "id": "block-id", "type": "meeting_notes" }]
+  "blocks": [{ "id": "block-id", "type": "synced_block" }]
 }
 \`\`\`
 
-Do not round-trip markdown through replace_content when omitted_block_types is present. The omitted blocks would be deleted from the page.
+Do not round-trip markdown through replace_content when omitted_block_types or read_only_block_rendered is present. omitted_block_types means the blocks are absent from the markdown and would be deleted; read_only_block_rendered means a Notion AI meeting-notes block was rendered as ordinary markdown and round-tripping replaces the native block with ordinary blocks.
+
+## read_only_block_rendered
+
+Returned by read_page, read_section, read_block, read_toggle, and duplicate_page when a Notion AI meeting-notes (or deprecated transcription) block is rendered as ordinary markdown. The native block is read-only and cannot be reconstructed from markdown, so round-tripping through replace_content replaces it with ordinary toggle/heading/paragraph blocks.
+
+Shape:
+\`\`\`json
+{
+  "code": "read_only_block_rendered",
+  "blocks": [
+    {
+      "id": "block-id",
+      "type": "meeting_notes",
+      "transcript_omitted": true,
+      "sections_unreadable": [
+        { "key": "transcript_block_id", "block_id": "section-id", "code": "object_not_found" }
+      ]
+    }
+  ],
+  "message": "Rendered read-only Notion AI meeting notes ..."
+}
+\`\`\`
+
+Subfields:
+
+- \`transcript_omitted\` (boolean, optional) — set to \`true\` when the meeting block had a transcript section pointer that was not fetched. Only emitted when transcript content was available but suppressed; a meeting block without a separate transcript pointer never carries this field. read_page accepts \`include_transcript: true\` to opt in; targeted-read tools always omit transcripts.
+- \`sections_unreadable\` (array, optional) — entries describe section pointers whose retrieve or descendant fetch failed. Each entry has \`key\` (the canonical pointer name: \`summary_block_id\`, \`notes_block_id\`, or \`transcript_block_id\`), \`block_id\` (the failed pointer), and an optional \`code\` (the Notion error code, e.g. \`object_not_found\`). Other sections continue to render even when one fails.
 
 ## truncated_properties
 
@@ -1588,7 +1615,7 @@ Update a section of a page by heading name. Finds the heading, replaces everythi
   },
   {
     name: "read_section",
-    description: `Read a single page section by heading name. Uses the same heading matching and boundary rules as update_section: headings are matched case-insensitively, H1 sections end at the next heading of any level, and H2/H3 sections end at the next heading of the same or higher level. Includes the heading block itself and recursively renders nested children only for blocks inside the selected section. If unsupported nested block types are omitted, the response includes warnings.`,
+    description: `Read a single page section by heading name. Uses the same heading matching and boundary rules as update_section: headings are matched case-insensitively, H1 sections end at the next heading of any level, and H2/H3 sections end at the next heading of the same or higher level. Includes the heading block itself and recursively renders nested children only for blocks inside the selected section. If unsupported nested block types are omitted, the response includes warnings. Notion AI meeting-notes blocks encountered in the result are rendered as a synthetic toggle and produce a \`read_only_block_rendered\` warning. Transcripts are not included from these tools.`,
     inputSchema: {
       type: "object",
       properties: {
@@ -1600,7 +1627,7 @@ Update a section of a page by heading name. Finds the heading, replaces everythi
   },
   {
     name: "read_block",
-    description: "Read one block by ID as markdown. Container blocks are fetched recursively with children. Unsupported root block types return a clear error; unsupported nested blocks are omitted and listed in warnings.",
+    description: "Read one block by ID as markdown. Container blocks are fetched recursively with children. Unsupported root block types return a clear error; unsupported nested blocks are omitted and listed in warnings. Notion AI meeting-notes blocks encountered in the result are rendered as a synthetic toggle and produce a `read_only_block_rendered` warning. Transcripts are not included from these tools.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1611,7 +1638,7 @@ Update a section of a page by heading name. Finds the heading, replaces everythi
   },
   {
     name: "read_toggle",
-    description: "Read one toggle by title from a page. Searches recursively and matches plain toggle blocks plus toggleable heading_1, heading_2, and heading_3 blocks using case-insensitive trimmed text. Missing titles return the available toggle titles.",
+    description: "Read one toggle by title from a page. Searches recursively and matches plain toggle blocks plus toggleable heading_1, heading_2, and heading_3 blocks using case-insensitive trimmed text. Missing titles return the available toggle titles. Notion AI meeting-notes blocks encountered in the result are rendered as a synthetic toggle and produce a `read_only_block_rendered` warning. Transcripts are not included from these tools.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1710,6 +1737,10 @@ To delete a block, pass \`archived: true\` instead of \`markdown\`. Exactly one 
     name: "read_page",
     description: `Read a page and return metadata plus markdown. Recursively fetches nested blocks and uses the same markdown conventions accepted by create_page. If unsupported block types are omitted from the markdown, they are listed in warnings. Do NOT round-trip markdown through replace_content when omitted_block_types warnings are present; omitted blocks would be deleted.
 
+Notion AI meeting notes are rendered as a synthetic toggle containing the title, an optional recording timestamp callout, and \`## Summary\` / \`## Notes\` heading sections. Transcript sections are included only with \`include_transcript: true\`. A \`read_only_block_rendered\` warning is emitted whenever such a block is rendered, indicating that round-tripping the markdown through \`replace_content\` will replace the native meeting-notes block with ordinary blocks.
+
+Note on \`max_blocks\`: the cap counts top-level page blocks only; section descendants of meeting-notes blocks are fetched in full regardless of the cap, consistent with how nested children of normal blocks are fetched.
+
 Long titles are paginated with max_property_items. For markdown conventions, warning shapes, and pagination details, read resources easy-notion://docs/markdown, easy-notion://docs/warnings, and easy-notion://docs/property-pagination.`,
     inputSchema: {
       type: "object",
@@ -1738,7 +1769,7 @@ Long titles are paginated with max_property_items. For markdown conventions, war
   },
   {
     name: "duplicate_page",
-    description: `Duplicate a page. Reads all blocks from the source and creates a new page with the same content that this server can represent. If the source contains block types this server does not yet support (e.g. child_page subpages, synced_block, child_database, link_to_page, meeting_notes), those are omitted from the duplicate AND listed in a \`warnings\` field. Deep-duplication of subpages is not yet supported.`,
+    description: `Duplicate a page. Reads all blocks from the source and creates a new page with the same content that this server can represent. If the source contains block types this server does not yet support (e.g. child_page subpages, synced_block, child_database, link_to_page), those are omitted from the duplicate AND listed in a \`warnings\` field with code \`omitted_block_types\`. Notion AI meeting notes are duplicated as ordinary toggle/heading/paragraph blocks (summary and notes only — transcripts are not duplicated); a \`read_only_block_rendered\` warning is emitted to identify meeting-notes blocks whose native identity was not preserved across the duplicate. Deep-duplication of subpages is not yet supported.`,
     inputSchema: {
       type: "object",
       properties: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -907,6 +907,92 @@ export function attachChildren(block: NotionBlock, children: NotionBlock[]): voi
   }
 }
 
+async function hydrateMeetingNotesBlock(
+  client: ReturnType<typeof createNotionClient>,
+  raw: any,
+  normalized: NotionBlock,
+  ctx: FetchContext,
+): Promise<boolean> {
+  if (raw.type !== "meeting_notes" && raw.type !== "transcription") {
+    return false;
+  }
+
+  const payload = raw[raw.type] ?? {};
+  const pointers = payload.children ?? {};
+  const summaryBlockId = typeof pointers.summary_block_id === "string" ? pointers.summary_block_id : undefined;
+  const notesBlockId = typeof pointers.notes_block_id === "string" ? pointers.notes_block_id : undefined;
+  const transcriptBlockId = typeof pointers.transcript_block_id === "string" ? pointers.transcript_block_id : undefined;
+  const hasSectionPointers = Boolean(summaryBlockId || notesBlockId || transcriptBlockId);
+  const includeTranscript = ctx.includeTranscript === true;
+
+  const children: NotionBlock[] = [];
+  const recording = payload.recording;
+  if (
+    typeof recording?.start_time === "string" &&
+    recording.start_time.length > 0 &&
+    typeof recording?.end_time === "string" &&
+    recording.end_time.length > 0
+  ) {
+    children.push({
+      type: "callout",
+      callout: {
+        rich_text: [{ type: "text", text: { content: `Recorded ${recording.start_time} – ${recording.end_time}`, link: null } }],
+        icon: { type: "emoji", emoji: "ℹ️" },
+      },
+    });
+  }
+
+  if (typeof payload.status === "string" && payload.status.length > 0 && payload.status !== "notes_ready") {
+    children.push({
+      type: "paragraph",
+      paragraph: { rich_text: [{ type: "text", text: { content: `Status: ${payload.status}`, link: null } }] },
+    });
+  }
+
+  const sectionsUnreadable: Array<{ key: string; block_id: string; code?: string }> = [];
+  const fetchSection = async (title: string, sectionBlockId: string, key: string): Promise<void> => {
+    try {
+      await retrieveBlock(client, sectionBlockId);
+      const descendants = await fetchBlocksRecursive(client, sectionBlockId, ctx);
+      children.push({
+        type: "heading_2",
+        heading_2: { rich_text: [{ type: "text", text: { content: title, link: null } }], is_toggleable: false },
+      });
+      children.push(...descendants);
+    } catch (err) {
+      const code = (err as any)?.body?.code ?? (err as any)?.code;
+      sectionsUnreadable.push({
+        key,
+        block_id: sectionBlockId,
+        ...(typeof code === "string" ? { code } : {}),
+      });
+    }
+  };
+
+  if (hasSectionPointers) {
+    if (summaryBlockId) await fetchSection("Summary", summaryBlockId, "summary_block_id");
+    if (notesBlockId) await fetchSection("Notes", notesBlockId, "notes_block_id");
+    if (includeTranscript && transcriptBlockId) await fetchSection("Transcript", transcriptBlockId, "transcript_block_id");
+  } else if (raw.has_children) {
+    children.push(...await fetchBlocksRecursive(client, raw.id, ctx));
+  }
+
+  if (children.length > 0) {
+    attachChildren(normalized, children);
+  }
+
+  const transcriptOmitted = Boolean(transcriptBlockId && !includeTranscript);
+  const entry: ReadOnlyRenderedBlock = {
+    id: raw.id,
+    type: raw.type as "meeting_notes" | "transcription",
+    ...(transcriptOmitted ? { transcript_omitted: true } : {}),
+    ...(sectionsUnreadable.length > 0 ? { sections_unreadable: sectionsUnreadable } : {}),
+  };
+  ctx.renderedReadOnly?.push(entry);
+
+  return true;
+}
+
 export async function fetchBlocksRecursive(
   client: ReturnType<typeof createNotionClient>,
   blockId: string,
@@ -924,7 +1010,11 @@ export async function fetchBlocksRecursive(
       continue;
     }
 
-    if (raw.has_children) {
+    const hydratedMeetingNotes = ctx
+      ? await hydrateMeetingNotesBlock(client, raw, normalized, ctx)
+      : false;
+
+    if (!hydratedMeetingNotes && raw.has_children) {
       const children = await fetchBlocksRecursive(client, raw.id, ctx);
       if (children.length > 0) {
         attachChildren(normalized, children);
@@ -948,7 +1038,11 @@ export async function fetchBlockRecursive(
     return { raw, block: null };
   }
 
-  if ((raw as any).has_children) {
+  const hydratedMeetingNotes = ctx
+    ? await hydrateMeetingNotesBlock(client, raw, block, ctx)
+    : false;
+
+  if (!hydratedMeetingNotes && (raw as any).has_children) {
     const children = await fetchBlocksRecursive(client, blockId, ctx);
     if (children.length > 0) {
       attachChildren(block, children);
@@ -974,7 +1068,11 @@ export async function fetchRawBlocksRecursive(
       continue;
     }
 
-    if (raw.has_children) {
+    const hydratedMeetingNotes = ctx
+      ? await hydrateMeetingNotesBlock(client, raw, normalized, ctx)
+      : false;
+
+    if (!hydratedMeetingNotes && raw.has_children) {
       const children = await fetchBlocksRecursive(client, raw.id, ctx);
       if (children.length > 0) {
         attachChildren(normalized, children);
@@ -1308,7 +1406,11 @@ export async function fetchBlocksWithLimit(
         continue;
       }
 
-      if (raw.has_children) {
+      const hydratedMeetingNotes = ctx
+        ? await hydrateMeetingNotesBlock(client, raw, normalized, ctx)
+        : false;
+
+      if (!hydratedMeetingNotes && raw.has_children) {
         const children = await fetchBlocksRecursive(client, raw.id, ctx);
         if (children.length > 0) {
           attachChildren(normalized, children);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1334,10 +1334,19 @@ function replacementToggleBodyBlocks(parsed: NotionBlock[], targetTitle: string)
   return getParsedBlockChildren(parsed[0]);
 }
 
-function omittedBlockWarnings(ctx: FetchContext): unknown[] {
-  return ctx.omitted.length > 0
-    ? [{ code: "omitted_block_types", blocks: ctx.omitted }]
-    : [];
+function readWarnings(ctx: FetchContext): unknown[] {
+  const out: unknown[] = [];
+  if (ctx.omitted.length > 0) {
+    out.push({ code: "omitted_block_types", blocks: ctx.omitted });
+  }
+  if ((ctx.renderedReadOnly ?? []).length > 0) {
+    out.push({
+      code: "read_only_block_rendered",
+      blocks: ctx.renderedReadOnly,
+      message: READ_ONLY_BLOCK_RENDERED_MESSAGE,
+    });
+  }
+  return out;
 }
 
 function targetedBlocksToMarkdown(blocks: NotionBlock[]): string {
@@ -1718,6 +1727,10 @@ Long titles are paginated with max_property_items. For markdown conventions, war
           type: "number",
           description:
             "Max rich_text segments returned when a page title exceeds 25 segments (uncommon in practice). Default 75. Set to 0 for unlimited. Negative values rejected. When the cap is hit, the response includes a truncated_properties warning with a how_to_fetch_all hint.",
+        },
+        include_transcript: {
+          type: "boolean",
+          description: "Include Notion AI meeting-notes transcript sections. Default false. Summary and Notes sections are always included when present.",
         },
       },
       required: ["page_id"],
@@ -2552,13 +2565,13 @@ export function createServer(
             });
           }
 
-          const ctx: FetchContext = { omitted: [] };
+          const ctx: FetchContext = { omitted: [], renderedReadOnly: [] };
           const blocks = await fetchRawBlocksRecursive(
             notion,
             allBlocks.slice(range.headingIndex, range.sectionEnd),
             ctx,
           );
-          const warnings = omittedBlockWarnings(ctx);
+          const warnings = readWarnings(ctx);
           return textResponse({
             page_id,
             heading: getBlockHeadingText(range.headingBlock) ?? heading,
@@ -2571,7 +2584,7 @@ export function createServer(
         case "read_block": {
           const notion = notionClientFactory();
           const { block_id } = args as { block_id: string };
-          const ctx: FetchContext = { omitted: [] };
+          const ctx: FetchContext = { omitted: [], renderedReadOnly: [] };
           const { raw, block } = await fetchBlockRecursive(notion, block_id, ctx);
           if (!block) {
             return textResponse({
@@ -2581,7 +2594,7 @@ export function createServer(
             });
           }
 
-          const warnings = omittedBlockWarnings(ctx);
+          const warnings = readWarnings(ctx);
           return textResponse({
             id: raw.id ?? block_id,
             type: raw.type ?? block.type,
@@ -2600,9 +2613,9 @@ export function createServer(
             });
           }
 
-          const ctx: FetchContext = { omitted: [] };
+          const ctx: FetchContext = { omitted: [], renderedReadOnly: [] };
           const blocks = await fetchRawBlocksRecursive(notion, [result.block], ctx);
-          const warnings = omittedBlockWarnings(ctx);
+          const warnings = readWarnings(ctx);
           return textResponse({
             page_id,
             title: getToggleTitle(result.block) ?? title,
@@ -2865,11 +2878,12 @@ export function createServer(
         }
         case "read_page": {
           const notion = notionClientFactory();
-          const { page_id, include_metadata, max_blocks, max_property_items } = args as {
+          const { page_id, include_metadata, max_blocks, max_property_items, include_transcript } = args as {
             page_id: string;
             include_metadata?: boolean;
             max_blocks?: number;
             max_property_items?: unknown;
+            include_transcript?: boolean;
           };
           const cap = max_property_items === undefined ? 75 : max_property_items;
           if (
@@ -2891,7 +2905,11 @@ export function createServer(
 
           let blocks: NotionBlock[];
           let hasMore = false;
-          const ctx: FetchContext = { omitted: [] };
+          const ctx: FetchContext = {
+            omitted: [],
+            renderedReadOnly: [],
+            includeTranscript: include_transcript === true,
+          };
 
           if (max_blocks !== undefined && max_blocks > 0) {
             const result = await fetchBlocksWithLimit(notion, page_id, max_blocks, ctx);
@@ -2912,10 +2930,7 @@ export function createServer(
             response.has_more = true;
           }
 
-          const warnings: unknown[] = [];
-          if (ctx.omitted.length > 0) {
-            warnings.push({ code: "omitted_block_types", blocks: ctx.omitted });
-          }
+          const warnings: unknown[] = [...readWarnings(ctx)];
           if (propertyWarnings.length > 0) {
             warnings.push({
               code: "truncated_properties",
@@ -2950,7 +2965,7 @@ export function createServer(
           const explicitParent = parent_page_id ?? sourcePage.parent?.page_id;
           const parent = await resolveParent(notion, explicitParent);
 
-          const ctx: FetchContext = { omitted: [] };
+          const ctx: FetchContext = { omitted: [], renderedReadOnly: [], includeTranscript: false };
           const sourceBlocks = await fetchBlocksRecursive(notion, page_id, ctx);
           const sourceIcon =
             sourcePage.icon?.type === "emoji" ? sourcePage.icon.emoji : undefined;
@@ -2965,8 +2980,9 @@ export function createServer(
           if (parent.type === "workspace") {
             response.note = "Created as a private workspace page. Use move_page to relocate.";
           }
-          if (ctx.omitted.length > 0) {
-            response.warnings = [{ code: "omitted_block_types", blocks: ctx.omitted }];
+          const warnings = readWarnings(ctx);
+          if (warnings.length > 0) {
+            response.warnings = warnings;
           }
           return textResponse(response);
         }

--- a/tests/block-warnings.test.ts
+++ b/tests/block-warnings.test.ts
@@ -84,8 +84,30 @@ function bulleted(id: string): Raw {
 function syncedBlock(id: string): Raw {
   return { id, type: "synced_block", synced_block: { synced_from: null }, has_children: false };
 }
-function meetingNotes(id: string): Raw {
-  return { id, type: "meeting_notes", meeting_notes: {}, has_children: false };
+function meetingNotes(
+  id: string,
+  options: {
+    title?: any[];
+    status?: string;
+    children?: Record<string, string>;
+    recording?: Record<string, any> | null;
+    has_children?: boolean;
+  } = {},
+): Raw {
+  return {
+    id,
+    type: "meeting_notes",
+    meeting_notes: {
+      title: options.title ?? [],
+      status: options.status ?? "notes_ready",
+      children: options.children ?? {},
+      recording: "recording" in options ? options.recording : null,
+    },
+    has_children: options.has_children ?? false,
+  };
+}
+function transcription(id: string): Raw {
+  return { id, type: "transcription", transcription: { title: [], status: "notes_ready", children: {}, recording: null }, has_children: false };
 }
 function linkToPage(id: string): Raw {
   return { id, type: "link_to_page", link_to_page: { type: "page_id", page_id: "some-page" }, has_children: false };
@@ -142,7 +164,7 @@ describe("Block-warnings on read_page and duplicate_page (G-3b)", () => {
     }
   });
 
-  it("read_page with a meeting_notes block reports it as omitted", async () => {
+  it("read_page with a meeting_notes block reports it as a rendered read-only block", async () => {
     const tree: Record<string, Raw[]> = {
       "page-meeting-notes": [para("b1"), meetingNotes("meeting-1")],
     };
@@ -151,7 +173,11 @@ describe("Block-warnings on read_page and duplicate_page (G-3b)", () => {
       const result = await client.callTool({ name: "read_page", arguments: { page_id: "page-meeting-notes" } });
       const response = extractResponse(parseToolText(result));
       expect(response.warnings).toEqual([
-        { code: "omitted_block_types", blocks: [{ id: "meeting-1", type: "meeting_notes" }] },
+        {
+          code: "read_only_block_rendered",
+          blocks: [{ id: "meeting-1", type: "meeting_notes" }],
+          message: expect.stringContaining("read-only Notion AI meeting notes"),
+        },
       ]);
     } finally {
       await close();
@@ -327,11 +353,14 @@ describe("Block-warnings on read_page and duplicate_page (G-3b)", () => {
       file: (id) => ({ id, type: "file", file: { type: "external", external: { url: "https://example.com/f.pdf" }, name: "f.pdf" }, has_children: false }),
       audio: (id) => ({ id, type: "audio", audio: { type: "external", external: { url: "https://example.com/a.mp3" } }, has_children: false }),
       video: (id) => ({ id, type: "video", video: { type: "external", external: { url: "https://example.com/v.mp4" } }, has_children: false }),
+      meeting_notes: meetingNotes,
+      transcription,
     };
     for (const type of SUPPORTED_BLOCK_TYPES) {
       expect(builders[type], `builder missing for supported type '${type}' — add one to this test`).toBeDefined();
     }
     for (const type of SUPPORTED_BLOCK_TYPES) {
+      if (type === "meeting_notes" || type === "transcription") continue; // covered by G3b-12 and tests/meeting-notes-read.test.ts
       const tree = { "page-invariant": [builders[type](`${type}-block`)] };
       const { client, close } = await connect(makeNotion(tree));
       try {
@@ -345,5 +374,10 @@ describe("Block-warnings on read_page and duplicate_page (G-3b)", () => {
         await close();
       }
     }
+  });
+
+  it("G3b-12: SUPPORTED_BLOCK_TYPES includes Notion AI meeting notes variants", () => {
+    expect(SUPPORTED_BLOCK_TYPES.has("meeting_notes")).toBe(true);
+    expect(SUPPORTED_BLOCK_TYPES.has("transcription")).toBe(true);
   });
 });

--- a/tests/meeting-notes-read.test.ts
+++ b/tests/meeting-notes-read.test.ts
@@ -1,0 +1,616 @@
+import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createServer } from "../src/server.js";
+
+type Raw = Record<string, any> & { id: string; type: string; has_children?: boolean };
+
+const PAGE_ID = "page-meeting-notes";
+const MEETING_ID = "meeting-notes-1";
+const SUMMARY_ID = "summary-section-1";
+const NOTES_ID = "notes-section-1";
+const TRANSCRIPT_ID = "transcript-section-1";
+const TITLE_TEXT = "AI meeting notes for 2026-05-08";
+const START_TIME = "2026-05-08T14:54:00.000Z";
+const END_TIME = "2026-05-08T14:58:00.000Z";
+
+function parseToolText(result: { content?: Array<{ type: string; text?: string }> }) {
+  const text = result.content?.find((item) => item.type === "text")?.text;
+  if (!text) throw new Error("expected text content");
+  return JSON.parse(text) as any;
+}
+
+function annotations(overrides: Record<string, any> = {}) {
+  return {
+    bold: false,
+    italic: false,
+    strikethrough: false,
+    underline: false,
+    code: false,
+    color: "default",
+    ...overrides,
+  };
+}
+
+function rt(content: string, annotationOverrides: Record<string, any> = {}) {
+  return [{
+    type: "text",
+    text: { content, link: null },
+    annotations: annotations(annotationOverrides),
+    plain_text: content,
+    href: null,
+  }];
+}
+
+function rtMention(
+  plainText: string,
+  opts: { mentionType?: "date" | "user"; start?: string } = {},
+) {
+  const mentionType = opts.mentionType ?? "user";
+  return [{
+    type: "mention",
+    mention: mentionType === "date"
+      ? {
+        type: "date",
+        date: { start: opts.start ?? "2026-05-08", end: null, time_zone: null },
+      }
+      : {
+        type: "user",
+        user: {
+          object: "user",
+          id: "user-1",
+          name: plainText.replace(/^@/, ""),
+          avatar_url: null,
+          type: "person",
+          person: { email: "some.user@example.com" },
+        },
+      },
+    annotations: annotations(),
+    plain_text: plainText,
+    href: null,
+  }];
+}
+
+function titleRichText() {
+  return [
+    ...rt("AI meeting notes for ", { bold: true }),
+    ...rt(""),
+    ...rtMention("2026-05-08", { mentionType: "date", start: "2026-05-08" }),
+  ];
+}
+
+function paragraph(id: string, text: string | any[], hasChildren = false): Raw {
+  return {
+    id,
+    type: "paragraph",
+    paragraph: { rich_text: typeof text === "string" ? rt(text) : text },
+    has_children: hasChildren,
+  };
+}
+
+function heading3(id: string, text: string): Raw {
+  return {
+    id,
+    type: "heading_3",
+    heading_3: { rich_text: rt(text), is_toggleable: false },
+    has_children: false,
+  };
+}
+
+function heading2(id: string, text: string): Raw {
+  return {
+    id,
+    type: "heading_2",
+    heading_2: { rich_text: rt(text), is_toggleable: false },
+    has_children: false,
+  };
+}
+
+function toDo(id: string, text: string, checked = false): Raw {
+  return {
+    id,
+    type: "to_do",
+    to_do: { rich_text: rt(text), checked },
+    has_children: false,
+  };
+}
+
+function bulleted(id: string, richText: string | any[]): Raw {
+  return {
+    id,
+    type: "bulleted_list_item",
+    bulleted_list_item: { rich_text: typeof richText === "string" ? rt(richText) : richText },
+    has_children: false,
+  };
+}
+
+function syncedBlock(id: string): Raw {
+  return { id, type: "synced_block", synced_block: { synced_from: null }, has_children: false };
+}
+
+type MeetingOptions = {
+  title?: any[];
+  status?: string;
+  children?: Record<string, string>;
+  recording?: { start_time?: string; end_time?: string } | null;
+  has_children?: boolean;
+};
+
+function meetingNotes(id: string, options: MeetingOptions = {}): Raw {
+  return meetingLikeBlock("meeting_notes", id, options);
+}
+
+function transcription(id: string, options: MeetingOptions = {}): Raw {
+  return meetingLikeBlock("transcription", id, options);
+}
+
+function meetingLikeBlock(type: "meeting_notes" | "transcription", id: string, options: MeetingOptions): Raw {
+  const body = {
+    title: options.title ?? titleRichText(),
+    status: options.status ?? "notes_ready",
+    children: options.children ?? {
+      summary_block_id: SUMMARY_ID,
+      notes_block_id: NOTES_ID,
+      transcript_block_id: TRANSCRIPT_ID,
+    },
+    recording: "recording" in options
+      ? options.recording
+      : { start_time: START_TIME, end_time: END_TIME },
+  };
+  return { id, type, [type]: body, has_children: options.has_children ?? false };
+}
+
+function sectionRoot(id: string): Raw {
+  return paragraph(id, [], true);
+}
+
+function objectNotFound(blockId: string) {
+  const err = new Error(`Could not find block ${blockId}`) as any;
+  err.code = "object_not_found";
+  err.body = { code: "object_not_found", message: `Could not find block ${blockId}` };
+  return err;
+}
+
+function makeNotion(
+  tree: Record<string, Raw[]>,
+  retrieve: Record<string, Raw> = {},
+  retrieveErrors: Record<string, any> = {},
+) {
+  return {
+    databases: { retrieve: vi.fn(), create: vi.fn() },
+    dataSources: { retrieve: vi.fn() },
+    pages: {
+      retrieve: vi.fn(async ({ page_id }: any) => ({
+        id: page_id,
+        url: `https://notion.so/${page_id}`,
+        properties: { title: { type: "title", title: [{ plain_text: "Meeting page" }] } },
+        parent: { type: "page_id", page_id: "parent-page-id" },
+      })),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    blocks: {
+      retrieve: vi.fn(async ({ block_id }: any) => {
+        if (retrieveErrors[block_id]) throw retrieveErrors[block_id];
+        const block = retrieve[block_id] ?? Object.values(tree).flat().find((candidate) => candidate.id === block_id);
+        if (!block) throw objectNotFound(block_id);
+        return block;
+      }),
+      children: {
+        list: vi.fn(async ({ block_id }: any) => ({
+          results: tree[block_id] ?? [],
+          has_more: false,
+          next_cursor: null,
+        })),
+        append: vi.fn(),
+      },
+      delete: vi.fn(),
+    },
+    users: { list: vi.fn(), me: vi.fn() },
+    search: vi.fn(),
+    comments: { list: vi.fn(), create: vi.fn() },
+    fileUploads: { create: vi.fn(), send: vi.fn() },
+  };
+}
+
+async function connect(notion: any) {
+  const server = createServer(() => notion, {});
+  const client = new McpClient(
+    { name: "meeting-notes-read-test", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  const [a, b] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(b), client.connect(a)]);
+  return {
+    client,
+    async close() {
+      await Promise.all([a.close(), b.close()]);
+    },
+  };
+}
+
+function standardFixture(options: {
+  block?: Raw;
+  summaryChildren?: Raw[];
+  notesChildren?: Raw[];
+  transcriptChildren?: Raw[];
+  retrieveErrors?: Record<string, any>;
+} = {}) {
+  const block = options.block ?? meetingNotes(MEETING_ID);
+  const tree: Record<string, Raw[]> = {
+    [PAGE_ID]: [block],
+    [SUMMARY_ID]: options.summaryChildren ?? [
+      heading3("summary-heading", "Decisions"),
+      toDo("summary-todo", "Send recap", false),
+      bulleted("summary-user-mention", [
+        ...rt("Owner: "),
+        ...rtMention("@Some User"),
+        ...rt(" will follow up."),
+      ]),
+    ],
+    [NOTES_ID]: options.notesChildren ?? [
+      heading3("notes-heading", "Discussion"),
+      bulleted("notes-bullet", "Discussed launch timing."),
+    ],
+    [TRANSCRIPT_ID]: options.transcriptChildren ?? [
+      paragraph("transcript-p1", "Transcript line one."),
+      paragraph("transcript-p2", "Transcript line two."),
+    ],
+  };
+  const retrieve = {
+    [SUMMARY_ID]: sectionRoot(SUMMARY_ID),
+    [NOTES_ID]: sectionRoot(NOTES_ID),
+    [TRANSCRIPT_ID]: sectionRoot(TRANSCRIPT_ID),
+    [MEETING_ID]: block,
+  };
+  const notion = makeNotion(tree, retrieve, options.retrieveErrors);
+  return { block, notion, tree };
+}
+
+describe("Notion AI meeting-notes read support", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a meeting_notes block as a synthetic toggle without fetching transcript by default", async () => {
+    const { notion } = standardFixture();
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID },
+      }));
+
+      expect(response.markdown).toContain(`+++ AI Meeting Notes: ${TITLE_TEXT}`);
+      expect(response.markdown).toContain(`> [!INFO]\n> Recorded ${START_TIME} – ${END_TIME}`);
+      expect(response.markdown).toContain("## Summary");
+      expect(response.markdown).toContain("## Notes");
+      expect(response.markdown).not.toContain("## Transcript");
+      expect(response.markdown).not.toContain("Transcript line one.");
+      expect(response.markdown).not.toContain("Status:");
+      expect(response.markdown).toContain("- Owner: @Some User will follow up.");
+      expect(response.warnings).toEqual([{
+        code: "read_only_block_rendered",
+        blocks: [{ id: MEETING_ID, type: "meeting_notes", transcript_omitted: true }],
+        message: expect.stringContaining("read-only Notion AI meeting notes"),
+      }]);
+      expect(notion.blocks.retrieve).not.toHaveBeenCalledWith(
+        expect.objectContaining({ block_id: TRANSCRIPT_ID }),
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("includes the transcript when read_page receives include_transcript: true", async () => {
+    const { notion } = standardFixture();
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID, include_transcript: true },
+      }));
+
+      expect(response.markdown).toContain("## Transcript");
+      expect(response.markdown).toContain("Transcript line one.");
+      expect(response.warnings).toHaveLength(1);
+      expect(response.warnings[0]).toMatchObject({
+        code: "read_only_block_rendered",
+        blocks: [{ id: MEETING_ID, type: "meeting_notes" }],
+        message: expect.stringContaining("read-only Notion AI meeting notes"),
+      });
+      expect(response.warnings[0].blocks[0]).not.toHaveProperty("transcript_omitted");
+      expect(notion.blocks.retrieve).toHaveBeenCalledWith(
+        expect.objectContaining({ block_id: TRANSCRIPT_ID }),
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("continues rendering summary and notes when a transcript section pointer is stale", async () => {
+    const { notion } = standardFixture({
+      retrieveErrors: { [TRANSCRIPT_ID]: objectNotFound(TRANSCRIPT_ID) },
+    });
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID, include_transcript: true },
+      }));
+
+      expect(response.markdown).toContain("## Summary");
+      expect(response.markdown).toContain("## Notes");
+      expect(response.markdown).not.toContain("## Transcript");
+      expect(response.warnings).toEqual([{
+        code: "read_only_block_rendered",
+        blocks: [{
+          id: MEETING_ID,
+          type: "meeting_notes",
+          sections_unreadable: [{
+            key: "transcript_block_id",
+            block_id: TRANSCRIPT_ID,
+            code: "object_not_found",
+          }],
+        }],
+        message: expect.stringContaining("read-only Notion AI meeting notes"),
+      }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("falls back to direct children when section pointers are absent and the meeting_notes block has children", async () => {
+    const block = meetingNotes(MEETING_ID, { children: {}, has_children: true });
+    const notion = makeNotion({
+      [PAGE_ID]: [block],
+      [MEETING_ID]: [
+        paragraph("fallback-1", "Fallback paragraph one."),
+        paragraph("fallback-2", "Fallback paragraph two."),
+      ],
+    }, { [MEETING_ID]: block });
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID },
+      }));
+
+      expect(response.markdown).toContain(`+++ AI Meeting Notes: ${TITLE_TEXT}`);
+      expect(response.markdown).toContain("Fallback paragraph one.");
+      expect(response.markdown).toContain("Fallback paragraph two.");
+      expect(response.warnings).toEqual([{
+        code: "read_only_block_rendered",
+        blocks: [{ id: MEETING_ID, type: "meeting_notes" }],
+        message: expect.stringContaining("read-only Notion AI meeting notes"),
+      }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("renders an unknown meeting_notes status literally", async () => {
+    const { notion } = standardFixture({
+      block: meetingNotes(MEETING_ID, { status: "processing_failed" }),
+    });
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID },
+      }));
+
+      expect(response.markdown).toContain("Status: processing_failed");
+    } finally {
+      await close();
+    }
+  });
+
+  it("suppresses the notes_ready status", async () => {
+    const { notion } = standardFixture({
+      block: meetingNotes(MEETING_ID, { status: "notes_ready" }),
+    });
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID },
+      }));
+
+      expect(response.markdown).not.toContain("Status:");
+      expect(response.markdown).toContain("## Summary");
+    } finally {
+      await close();
+    }
+  });
+
+  it("renders the deprecated transcription variant with the same synthetic toggle contract", async () => {
+    const { notion } = standardFixture({
+      block: transcription(MEETING_ID),
+    });
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID },
+      }));
+
+      expect(response.markdown).toContain(`+++ AI Meeting Notes: ${TITLE_TEXT}`);
+      expect(response.markdown).toContain("## Summary");
+      expect(response.markdown).toContain("## Notes");
+      expect(response.warnings).toEqual([{
+        code: "read_only_block_rendered",
+        blocks: [{ id: MEETING_ID, type: "transcription", transcript_omitted: true }],
+        message: expect.stringContaining("read-only Notion AI meeting notes"),
+      }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("keeps omitted_block_types warnings from unknown section descendants alongside read_only_block_rendered", async () => {
+    const { notion } = standardFixture({
+      summaryChildren: [
+        heading3("summary-heading", "Decisions"),
+        syncedBlock("summary-sync"),
+        bulleted("summary-bullet", "Visible summary content."),
+      ],
+    });
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID },
+      }));
+
+      expect(response.markdown).toContain("Visible summary content.");
+      expect(response.warnings).toEqual(expect.arrayContaining([
+        {
+          code: "omitted_block_types",
+          blocks: [{ id: "summary-sync", type: "synced_block" }],
+        },
+        {
+          code: "read_only_block_rendered",
+          blocks: [{ id: MEETING_ID, type: "meeting_notes", transcript_omitted: true }],
+          message: expect.stringContaining("read-only Notion AI meeting notes"),
+        },
+      ]));
+    } finally {
+      await close();
+    }
+  });
+
+  it("omits the recording INFO callout when recording is null", async () => {
+    const { notion } = standardFixture({
+      block: meetingNotes(MEETING_ID, { recording: null }),
+    });
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID },
+      }));
+
+      expect(response.markdown).toContain(`+++ AI Meeting Notes: ${TITLE_TEXT}`);
+      expect(response.markdown).not.toContain("> [!INFO]");
+      expect(response.markdown).not.toContain("Recorded");
+    } finally {
+      await close();
+    }
+  });
+
+  it.each([
+    ["missing end time", { start_time: START_TIME, end_time: "" }],
+    ["missing start time", { start_time: "", end_time: END_TIME }],
+  ])("omits the recording INFO callout when recording is partial: %s", async (_name, recording) => {
+    const { notion } = standardFixture({
+      block: meetingNotes(MEETING_ID, { recording }),
+    });
+    const { client, close } = await connect(notion);
+
+    try {
+      const response = parseToolText(await client.callTool({
+        name: "read_page",
+        arguments: { page_id: PAGE_ID },
+      }));
+
+      expect(response.markdown).toContain(`+++ AI Meeting Notes: ${TITLE_TEXT}`);
+      expect(response.markdown).not.toContain("> [!INFO]");
+      expect(response.markdown).not.toContain("Recorded");
+    } finally {
+      await close();
+    }
+  });
+
+  it("covers targeted read behavior for meeting notes blocks and synthetic toggle discovery", async () => {
+    const sectionMeeting = meetingNotes("section-meeting", {
+      children: {
+        summary_block_id: "section-summary",
+        notes_block_id: "section-notes",
+        transcript_block_id: "section-transcript",
+      },
+    });
+    const tree: Record<string, Raw[]> = {
+      [MEETING_ID]: [
+        paragraph("block-summary-child", "Read block summary."),
+      ],
+      [SUMMARY_ID]: [
+        paragraph("summary-child", "Summary from read_block."),
+      ],
+      [NOTES_ID]: [
+        paragraph("notes-child", "Notes from read_block."),
+      ],
+      [TRANSCRIPT_ID]: [
+        paragraph("transcript-child", "Transcript should stay hidden."),
+      ],
+      "section-page": [
+        heading2("target-heading", "Target"),
+        sectionMeeting,
+        heading2("next-heading", "Next"),
+      ],
+      "section-summary": [paragraph("section-summary-child", "Summary from read_section.")],
+      "section-notes": [paragraph("section-notes-child", "Notes from read_section.")],
+      "section-transcript": [paragraph("section-transcript-child", "Hidden section transcript.")],
+      "toggle-page": [meetingNotes("toggle-meeting")],
+    };
+    const retrieve: Record<string, Raw> = {
+      [MEETING_ID]: meetingNotes(MEETING_ID),
+      [SUMMARY_ID]: sectionRoot(SUMMARY_ID),
+      [NOTES_ID]: sectionRoot(NOTES_ID),
+      [TRANSCRIPT_ID]: sectionRoot(TRANSCRIPT_ID),
+      "section-meeting": sectionMeeting,
+      "section-summary": sectionRoot("section-summary"),
+      "section-notes": sectionRoot("section-notes"),
+      "section-transcript": sectionRoot("section-transcript"),
+    };
+    const notion = makeNotion(tree, retrieve);
+    const { client, close } = await connect(notion);
+
+    try {
+      const toggleMiss = parseToolText(await client.callTool({
+        name: "read_toggle",
+        arguments: { page_id: "toggle-page", title: `AI Meeting Notes: ${TITLE_TEXT}` },
+      }));
+      expect(toggleMiss.error).toContain("Toggle not found");
+      expect(toggleMiss.available_toggles).not.toContain(`AI Meeting Notes: ${TITLE_TEXT}`);
+
+      const blockResponse = parseToolText(await client.callTool({
+        name: "read_block",
+        arguments: { block_id: MEETING_ID },
+      }));
+      expect(blockResponse.error).toBeUndefined();
+      expect(blockResponse.markdown).toContain(`+++ AI Meeting Notes: ${TITLE_TEXT}`);
+      expect(blockResponse.markdown).toContain("## Summary");
+      expect(blockResponse.markdown).toContain("## Notes");
+      expect(blockResponse.warnings).toEqual([{
+        code: "read_only_block_rendered",
+        blocks: [{ id: MEETING_ID, type: "meeting_notes", transcript_omitted: true }],
+        message: expect.stringContaining("read-only Notion AI meeting notes"),
+      }]);
+
+      const sectionResponse = parseToolText(await client.callTool({
+        name: "read_section",
+        arguments: { page_id: "section-page", heading: "Target" },
+      }));
+      expect(sectionResponse.markdown).toContain(`+++ AI Meeting Notes: ${TITLE_TEXT}`);
+      expect(sectionResponse.markdown).toContain("Summary from read_section.");
+      expect(sectionResponse.warnings).toEqual([{
+        code: "read_only_block_rendered",
+        blocks: [{ id: "section-meeting", type: "meeting_notes", transcript_omitted: true }],
+        message: expect.stringContaining("read-only Notion AI meeting notes"),
+      }]);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/resources.test.ts
+++ b/tests/resources.test.ts
@@ -78,7 +78,11 @@ describe("MCP documentation resources", () => {
     const expectedShapes = [
       [
         "omitted_block_types",
-        '"blocks": [{ "id": "block-id", "type": "meeting_notes" }]',
+        '"blocks": [{ "id": "block-id", "type": "synced_block" }]',
+      ],
+      [
+        "read_only_block_rendered",
+        '"transcript_omitted": true',
       ],
       [
         "truncated_properties",


### PR DESCRIPTION
## v0.9.1

Patch release. Additive only, no contract changes.

### Added

- **Notion AI meeting-notes read support.** `read_page`, `read_section`, `read_block`, `read_toggle`, and `duplicate_page` render Notion's read-only AI meeting-notes (and deprecated `transcription`) blocks as a synthetic toggle containing the title, an optional recording timestamp callout, and `## Summary` / `## Notes` heading sections. `read_page` accepts `include_transcript: true` to include transcript sections; the CLI exposes `--include-transcript` on `page read`. A new `read_only_block_rendered` warning is emitted alongside the rendered markdown, with `transcript_omitted` and `sections_unreadable` subfields documenting what was suppressed or failed to fetch. Round-tripping the markdown through `replace_content` replaces these blocks with ordinary blocks; the warning lets agents detect that before writing back.

### Notes

- Tag-triggered Release CI on `v0.9.1` is the validation event for the Node 24 / Trusted Publishing fix from `e06e2ee`.
