### PR TITLE
docs(recipes): make Recipe 1 dedupe deterministic and re-run-safe

### DIFF
--- a/.meta/recipes-dedupe-rerun-evidence-2026-06-26.md
+++ b/.meta/recipes-dedupe-rerun-evidence-2026-06-26.md
@@ -1,0 +1,73 @@
+# Recipe 1 deterministic re-run safety — live smoke evidence (2026-06-26)
+
+Run by the builder PM against live Notion via this session's `easy-notion` stdio MCP
+(bot: Iris, `320be876-242f-8131-8f63-0027e8b63e24`). Sandbox is disposable.
+
+Supersedes the Recipe 1 boundary in `.meta/recipes-smoke-evidence-2026-06-25.md`
+(which recorded Recipe 1 as single-run-safe / re-run-unsafe). Recipe 1 is now
+re-run-safe / idempotent.
+
+## The fix (doc-only, frozen-contract-safe)
+
+Recipe 1 previously keyed dedupe on `Item Key` = an LLM-derived slug of the action
+text. That is non-deterministic: a re-run that rewords an item yields a new slug
+and a duplicate row.
+
+The fix keys `Item Key` on the source line's stable Notion identity,
+`<sourcePageId>:<sourceBlockId>`. The block ID is stable across reads and across
+rewordings, so re-running over the same notes always produces the same key and the
+existing-row dedupe query skips instead of inserting.
+
+No public-contract change: no new tool, no new argument, no schema change. The
+`Item Key` property stays `rich_text`; the dedupe filter shape is byte-identical;
+only the key value and the agent's derivation procedure change. The block ID is
+obtained through the existing `search_in_page` tool.
+
+### Quirk discovered
+
+`read_page` returns markdown with NO block IDs (they are dropped in
+blocks-to-markdown conversion). The only existing read tool that surfaces per-line
+stable block IDs is `search_in_page`, whose `matches[].block_id` is the stable
+Notion block UUID. The recipe therefore instructs the agent to resolve each item's
+source block ID via `search_in_page` on a verbatim substring of the source line.
+For pasted (non-page) notes, the agent first saves them as a Notion page with
+`create_page`, then resolves IDs via `search_in_page`.
+
+## Live smoke — PROVEN idempotent
+
+**Sandbox page:** `38bbe876-242f-8179-9c21-c9d66620eec8` (Recipes Cookbook Sandbox 2026-06-25)
+
+**Meeting-notes source page:** `38bbe876-242f-81f1-97b7-df935d050a24`
+(Q3 Planning Sync — Meeting Notes, dedupe smoke 2026-06-26), with 5 action-item
+bullet lines.
+
+**Action Items DB:** `05d2452c-202d-4483-a7f3-8772f1c4600d`
+Schema unchanged: Name(title), Item Key(rich_text), Owner(rich_text), Due(date),
+Status(status), Flags(multi_select), Source(rich_text).
+
+`search_in_page` on each verbatim source line returned exactly 1 match with the
+source block's stable ID (each confirmed equal to the block ID `create_page`
+assigned the line). The 5 source blocks and resulting keys
+(all prefixed with sourcePageId `38bbe876-242f-81f1-97b7-df935d050a24:`):
+
+| Source line | sourceBlockId |
+|---|---|
+| Draft the v1.1 release notes by Friday — James | `38bbe876-242f-81c9-86c6-d9a792fc70b7` |
+| Follow up with design team about onboarding flow — Priya | `38bbe876-242f-81d4-86ae-e18fbd7f8511` |
+| Investigate latency spike in search endpoint — Marco | `38bbe876-242f-81bc-b9c8-c43ba21cf44b` |
+| Update the pricing page | `38bbe876-242f-81aa-9480-e46685ff7632` |
+| Schedule follow-up review next week | `38bbe876-242f-8197-b1fa-c4e5dc59f102` |
+
+**Run 1** (DB empty -> all 5 dedupe queries return empty -> insert all 5):
+`query_database` (no filter) afterward returned **5 rows**.
+
+**Run 2** (same unchanged notes): for each of the 5 items the deterministic key was
+re-derived and a `query_database` `Item Key` `rich_text equals` query was issued.
+Every one of the 5 returned **exactly 1 existing row** -> all 5 skipped, zero
+inserts. `query_database` (no filter) afterward returned **5 rows**.
+
+**Before run 1: 0 rows. After run 1: 5 rows. After run 2: 5 rows. Zero duplicates.**
+
+This is the determinism the old text-slug key could not provide: even if the agent
+rewords an item's `Name` on the second pass, the dedupe key is the source block ID,
+which is unchanged, so the row is matched and skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Notion's native limits. Includes copy-paste blocks for claude.ai connector
   users. Both recipes were verified against live Notion. Content and docs only;
   no version bump.
+- **Recipe 1 deterministic dedupe docs.** Recipe 1 of the notion-recipes
+  cookbook now keys dedupe on the source block's stable Notion identity
+  (`<pageId>:<blockId>`) instead of an LLM-derived text slug, so re-running over
+  the same notes is idempotent. Docs only, no version bump.
 
 ## [1.0.1] - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -516,15 +516,15 @@ easy-notion-mcp supports creating and updating databases with typed schemas, que
 
 These recipes point your own agent at Notion. The agent owns the intelligence; easy-notion-mcp supplies deterministic connective tissue through the existing MCP tools, so the recipes run on demand with zero second install. They are free and sovereign: your own agent, your own token, no-OAuth API-token setup, and free-plan database queries.
 
-These steps work through the MCP tools or the claude.ai connector when the equivalent tools are enabled. Recipe 2 additionally works through the `easy-notion` CLI skill in `skills/easy-notion-cli/`; Recipe 1 needs `create_database` and a structured dedupe filter, neither of which the current CLI surface exposes. Claude Code agents can use the operational skill in `skills/notion-recipes/`.
+These steps work through the MCP tools or the claude.ai connector when the equivalent tools are enabled. Recipe 2 additionally works through the `easy-notion` CLI skill in `skills/easy-notion-cli/`; Recipe 1 needs `create_database`, source-block lookup with `search_in_page`, and a structured dedupe filter, and the current CLI surface does not expose that full workflow. Claude Code agents can use the operational skill in `skills/notion-recipes/`.
 
 ### Recipe 1: meeting notes to action items
 
-This recipe turns a meeting-notes page or pasted notes into deduplicated rows in an Action Items database. The tool sequence is `create_database` once, then per run `read_page` when the source is a page, `query_database` with an exact `Item Key` filter for each candidate item, `add_database_entry` or `add_database_entries` for new rows, and a final `query_database` verification.
+This recipe turns a meeting-notes page or pasted notes into deduplicated rows in an Action Items database. The tool sequence is `create_database` once, then per run `read_page` when the source is a page, `search_in_page` to resolve each item's source block ID, `query_database` with an exact `Item Key` filter for each candidate item, `add_database_entry` or `add_database_entries` for new rows, and a final `query_database` verification.
 
-The proven live result was 5 rows from a planning meeting. Missing owners and due dates were stored in the `Flags` multi-select, not in `Source`, and a `query_database` filter of `{"property":"Item Key","rich_text":{"equals":"draft-v1-1-release-notes"}}` returned exactly 1 row. A free-text search for the shared meeting name returned every row because it also scanned `Source`, so this recipe uses the exact Item Key filter for dedupe.
+The proven live result was 5 rows from a planning meeting. Missing owners and due dates were stored in the `Flags` multi-select, not in `Source`, and a `query_database` filter of `{"property":"Item Key","rich_text":{"equals":"38bbe876-242f-81f1-97b7-df935d050a24:38bbe876-242f-81c9-86c6-d9a792fc70b7"}}` returned exactly 1 row. Running twice over the same notes left the count at 5 with zero duplicates. A free-text search for the shared meeting name returned every row because it also scanned `Source`, so this recipe uses the exact Item Key filter for dedupe.
 
-Safety boundary: Recipe 1 is single-run-safe but re-run-unsafe today. The Item Key equals filter blocks re-inserting an item whose key matches exactly, but the key is derived by the agent from the action wording. Re-running over the same notes with reworded items produces new keys and therefore duplicate rows. Run it once per set of notes. Deterministic re-run safety is tracked for a future `block-id-dedupe-helper`, keying off the source block ID.
+Safety boundary: Recipe 1 is re-run-safe and idempotent because `Item Key` stores the source line's stable Notion identity (`<pageId>:<blockId>`), not the action wording.
 
 #### Copy-paste for claude.ai connector users, Recipe 1
 
@@ -551,10 +551,12 @@ Read the meeting notes or use the pasted notes. Extract only discrete action ite
 - Name: the action text
 - Owner: the named assignee, or blank
 - Due: the stated date as ISO YYYY-MM-DD, or blank
-- Item Key: a stable lowercase hyphenated slug of the action text, such as draft-v1-1-release-notes
+- Item Key: the source line's stable identity, formatted as <sourcePageId>:<sourceBlockId>
 - Source: the meeting title plus date, with no flags stashed here
 - Status: Not started
 - Flags: add needs-owner if no owner, and needs-due if no due date
+
+Resolve sourceBlockId with search_in_page. read_page returns markdown without block IDs. For a Notion-page source, call read_page to extract items, then for each item call search_in_page with a verbatim, distinctive substring of that item's original source line. Use the matches[].block_id whose text is that source line. If several blocks match, use a longer verbatim substring to isolate one block. For pasted notes, first save them as a Notion page with create_page, then proceed through search_in_page. Do not rely on block IDs from create_page, which returns only {id,title,url}. If one source line contains multiple distinct actions, append a stable ordinal suffix in source order, such as :1 or :2, to keep keys unique.
 
 Before inserting each item, dedupe with an exact Item Key filter:
 {"property":"Item Key","rich_text":{"equals":"<that item's key>"}}
@@ -563,7 +565,7 @@ If the query returns no results, insert the row with simple key-value properties
 
 After inserting, query the database and summarize the rows created and skipped.
 
-Safety boundary: this recipe is single-run-safe but re-run-unsafe today. The Item Key equals filter blocks re-inserting an item whose key matches exactly, but the key is derived from the action wording. Re-running over the same notes with reworded items produces new keys and therefore duplicate rows. Run it once per set of notes.
+Re-running is safe and idempotent because the exact Item Key filter uses the source line's stable Notion identity, not the action wording.
 ```
 
 ### Recipe 2: bulk-edit, find-replace, and repair

--- a/skills/notion-recipes/SKILL.md
+++ b/skills/notion-recipes/SKILL.md
@@ -5,13 +5,13 @@ description: Use this skill when a user wants to turn meeting notes into a track
 
 # Notion Recipes
 
-Use these recipes with easy-notion's MCP tools, or through the claude.ai connector when the equivalent tools are enabled. Recipe 2 (repair and find-replace) also works through the `easy-notion` CLI skill in `skills/easy-notion-cli/`. Recipe 1 does not: the CLI does not expose `create_database`, and its `database query` surface is free-text only, which this recipe's dedupe step explicitly avoids.
+Use these recipes with easy-notion's MCP tools, or through the claude.ai connector when the equivalent tools are enabled. Recipe 2 (repair and find-replace) also works through the `easy-notion` CLI skill in `skills/easy-notion-cli/`. Recipe 1 does not: it needs `create_database`, source-block lookup with `search_in_page`, and structured database filters, and the current CLI surface does not expose that full workflow.
 
 ## Recipe 1: Meeting Notes To Action Items
 
 Turn a meeting-notes page or pasted notes into deduplicated rows in an Action Items database.
 
-Safety boundary: Recipe 1 is single-run-safe but re-run-unsafe today. The Item Key equals filter blocks re-inserting an item whose key matches exactly, but the key is derived by the agent from the action wording. Re-running over the same notes with reworded items produces new keys and therefore duplicate rows. Run it once per set of notes. Deterministic re-run safety is tracked for a future `block-id-dedupe-helper`, keying off the source block ID.
+Safety boundary: Recipe 1 is re-run-safe and idempotent because `Item Key` stores the source line's stable Notion identity (`<pageId>:<blockId>`), not the action wording.
 
 1. Create the Action Items database once with `create_database` under the user-selected parent page:
 
@@ -36,11 +36,12 @@ Safety boundary: Recipe 1 is single-run-safe but re-run-unsafe today. The Item K
    - `Name`: the action text.
    - `Owner`: the named assignee, or blank.
    - `Due`: the stated date as ISO `YYYY-MM-DD`, or blank.
-   - `Item Key`: a stable slug of the action text, lowercase and hyphenated, for example `draft-v1-1-release-notes`.
+   - `Item Key`: the source line's stable identity, formatted as `<sourcePageId>:<sourceBlockId>`.
    - `Source`: the meeting title plus date. Do not stash flags here.
    - `Status`: `Not started`.
    - `Flags`: add `needs-owner` if no owner, and `needs-due` if no due date. These are `multi_select` values, not text in `Source`.
-4. Dedupe before insert. For each item, call `query_database` with this exact filter shape:
+4. Resolve `sourceBlockId` with `search_in_page`. `read_page` returns markdown without block IDs. For a Notion-page source, call `read_page` to extract items, then for each item call `search_in_page` with a verbatim, distinctive substring of that item's original source line. Use the `matches[].block_id` whose text is that source line. If several blocks match, use a longer verbatim substring to isolate one block. For pasted notes, first save them as a Notion page with `create_page`, then proceed through `search_in_page`; do not rely on block IDs from `create_page`, which returns only `{id,title,url}`. If one source line contains multiple distinct actions, append a stable ordinal suffix in source order, such as `:1` or `:2`, to keep keys unique.
+5. Dedupe before insert. For each item, call `query_database` with this exact filter shape:
 
 ```json
 {
@@ -55,12 +56,12 @@ Safety boundary: Recipe 1 is single-run-safe but re-run-unsafe today. The Item K
 
 If `results` is empty, insert the item. Otherwise skip it. Do not dedupe with free-text `query_database text=...`; text search also scans `Source` and can produce false matches for every row from the same meeting.
 
-5. Insert new rows with `add_database_entry`, or batch them with `add_database_entries`, using simple key-value properties such as:
+6. Insert new rows with `add_database_entry`, or batch them with `add_database_entries`, using simple key-value properties such as:
 
 ```json
 {
   "Name": "Draft the v1.1 release notes",
-  "Item Key": "draft-v1-1-release-notes",
+  "Item Key": "38bbe876-242f-81f1-97b7-df935d050a24:38bbe876-242f-81c9-86c6-d9a792fc70b7",
   "Owner": "James",
   "Due": "2026-06-26",
   "Status": "Not started",
@@ -69,7 +70,7 @@ If `results` is empty, insert the item. Otherwise skip it. Do not dedupe with fr
 }
 ```
 
-6. Verify by querying the database. The live smoke test produced 5 rows, with missing owners and dates represented in `Flags`, and an Item Key `rich_text equals` query returned exactly 1 matching row.
+7. Verify by querying the database. The live smoke test produced 5 rows, with missing owners and dates represented in `Flags`; running twice over the same notes left the count unchanged. An Item Key `rich_text equals` query on a `<pageId>:<blockId>` key returned exactly 1 matching row.
 
 ## Recipe 2: Bulk Edit, Find-Replace, And Repair
 


### PR DESCRIPTION
## What

Makes cookbook Recipe 1 (meeting-notes → deduplicated Action Items DB) **re-run-safe**. It was previously labeled single-run-safe / re-run-unsafe: re-running over the same notes produced duplicate rows, because dedupe keyed on `Item Key` = an LLM-derived text slug of the action wording (non-deterministic, so a reworded item on a re-run yields a new key and a duplicate).

This re-keys `Item Key` on the source line's **stable Notion identity**, `<sourcePageId>:<sourceBlockId>`. The block ID is stable across reads and rewordings, so a second run re-derives the same key and the existing-row dedupe query skips instead of inserting.

## Scope

Doc-only and frozen-contract-safe:

- Files: `skills/notion-recipes/SKILL.md`, `README.md`, `CHANGELOG.md`, plus a `.meta` evidence file. **No `src/` or `tests/` changes.**
- No new tool, no new argument, no schema change. `Item Key` stays `rich_text`; the dedupe filter shape is byte-identical. Only the key value and the agent's derivation procedure change.
- The "re-run-unsafe" boundary and the "future helper" promise are removed from SKILL.md and README.

## Note for review

`read_page` returns markdown with block IDs stripped, so the recipe resolves each item's source block ID via the existing **`search_in_page`** tool (`matches[].block_id`) on a verbatim source-line substring. Please scrutinize that substring-resolution step: it is robust on distinct lines, but worth a look for ambiguity when two source lines are very similar.

## Evidence (live Notion, runtime)

Ran Recipe 1's flow against a disposable sandbox twice over the same notes:

- Before run 1: **0 rows**. After run 1: **5 rows** (empty DB → all 5 dedupe queries empty → 5 inserts).
- After run 2 (same notes): **5 rows**. Each of the 5 `Item Key rich_text equals` queries returned exactly 1 existing row → all 5 skipped. **Zero inserts, zero duplicates.**

Full evidence in `.meta/recipes-dedupe-rerun-evidence-2026-06-26.md`.

## CI note

`tests/http-bin-startup.test.ts` can flake under load (12s process-startup timeout; passes in ~7.2s run in isolation). This change is doc-only and cannot affect HTTP bin startup, so re-run that job if it trips.
