### PR TITLE
ci: add version-stable ci-required aggregator gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,16 @@ jobs:
           # executed (Express is our HTTP layer) and qs.stringify is never called.
           # Grounded per-advisory writeup: .meta/audits/dep-vuln-exploitability-2026-06-14.md
           allow-ghsas: GHSA-j3q9-mxjg-w52f, GHSA-27v5-c462-wpq7, GHSA-xrhx-7g5j-rcj5, GHSA-3hrh-pfw6-9m5x, GHSA-f577-qrjj-4474, GHSA-2gcr-mfcq-wcc3, GHSA-q8mj-m7cp-5q26
+
+  ci-required:
+    needs: [ci]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify matrix result
+        run: |
+          if [ "${{ needs.ci.result }}" != "success" ]; then
+            echo "ci matrix result: ${{ needs.ci.result }}"
+            exit 1
+          fi
+          echo "ci matrix succeeded"


### PR DESCRIPTION
## What

Adds a single version-stable `ci-required` aggregator job to `.github/workflows/ci.yml` that depends on the whole `ci` matrix and passes only when every leg succeeds.

## Why

Branch-protection required status checks are named `ci (20)` / `ci (22)` — the context name encodes the Node matrix version. GitHub requires those literal names and has no link to the workflow, so bumping the matrix turns the old required context into a phantom that never reports, and PRs hang forever on "Expected — Waiting for status to be reported." This just happened: protection still required `ci (18)` after the matrix moved to `[20, 22]`.

`ci-required` has a fixed name that does not encode versions, so the matrix can change freely and the required context never moves.

## Behavior

- All matrix legs succeed → `needs.ci.result == 'success'` → gate passes.
- Any leg fails / cancelled / skipped → `if: always()` still runs the gate → it exits non-zero and reports failure (the `if: always()` is load-bearing; without it a failed dependency skips the gate and the required context never reports, re-creating the hang).

YAML validated (`yaml.safe_load`).

## Follow-up ops (not in this PR)

After this merges and `ci-required` reports at least once, branch protection on `dev` and `main` will be updated to require `ci-required` and retire the version-encoded `ci (20)` / `ci (22)` contexts. Requiring `ci-required` before it has ever reported would re-create the exact hang this fixes, so the protection flip is deliberately sequenced after the first run.
