### PR TITLE
feat(cli): one-command bootstrap wizard — Phase 1 (Claude Code)

### DIFF
--- a/.meta/plans/one-command-bootstrap-2026-06-26.md
+++ b/.meta/plans/one-command-bootstrap-2026-06-26.md
@@ -1,0 +1,211 @@
+# Plan: One-command bootstrap for easy-notion-mcp
+
+- **Status:** Draft for human review (Plan → review → build)
+- **Date:** 2026-06-26
+- **Branch:** `plan/one-command-bootstrap`
+- **Ratifies:** decision `invest-in-one-command-bootstrap` (2026-06-25) — a one-command bootstrap is the highest *adoption* lever post-1.0.
+- **Scope:** Plan/spec only. No implementation in this branch.
+
+---
+
+## 1. The problem, stated honestly
+
+Setup today is two separable chores, and only one of them is automatable:
+
+1. **Client registration** — getting an `easy-notion-mcp` entry into the MCP client's config. Today this is a hand-copied `claude mcp add ...` incantation, or hand-edited JSON for Cursor/Windsurf/Claude Desktop/VS Code, each with a different file path and (for VS Code) a different top-level key. **Automatable.**
+2. **Credential acquisition** — creating a Notion integration at notion.so/my-integrations, copying the token, and *sharing pages with the integration*. **Not automatable** for the API-token path: those clicks happen inside Notion's UI on Notion's domain. OAuth could remove the copy-paste, but only by standing up a public HTTP server with a registered public integration — heavyweight, and on the *experimental* (unfrozen) auth surface.
+
+So "one command" cannot mean "zero human steps." It means: **collapse the read-docs → create-integration → guess-the-incantation → edit-JSON → share-pages → test loop into a single guided wizard that does every step it legitimately can, validates the result live, and hands the user the exact remaining manual step when it hits one it can't.**
+
+That reframing is the core of this plan. A bootstrap that *claims* to be one-command but silently leaves the user with a valid token and zero shared pages (the #1 silent-failure mode) is worse than the current honest README.
+
+## 2. What "one command" sets up (the command surface)
+
+**Primary documented command:**
+
+```bash
+npx easy-notion-mcp@latest init
+```
+
+`@latest` is deliberate — `npx` will otherwise happily run a stale cached copy.
+
+**Implementation note (additive, load-bearing):** the `easy-notion-mcp` bin → `dist/index.js`, which today reads `NOTION_TOKEN` and **constructs the server at module top level**, exiting immediately if the token is unset (`src/index.ts:7-11`). Two things follow (both from Codex review):
+
+- The top-level work must be refactored into a `main()` so the `init` branch can run *before* the token check and server construction.
+- The branch should be a **lazy dynamic import**: `if (argv[2] === "init") { await import("./cli/init.js"); return; }` placed first. This keeps no-arg stdio startup from pulling the wizard/prompt stack into the hot path, and isolates the `init` code from the server-boot code.
+
+The branch triggers **only** on an explicit `init`/`setup` first arg. The stdio invariant is stated precisely in §5 (not "byte-for-byte" — see there).
+
+**Wizard does NOT route through `runCli`'s return path.** The `easy-notion` CLI (`src/cli/run.ts:2041`) always JSON-serializes command results to stdout (`writeJson`). That is correct for machine-consumed CLI commands and *wrong* for an interactive human wizard. The wizard is its own module (`src/cli/init.ts`) with its own human-facing I/O; it is reachable as `easy-notion init` via a dispatch case, but that case calls the wizard directly and must not let the JSON result wrapper leak into the UX. One implementation, two entrypoints (`npx easy-notion-mcp init` documented; `easy-notion init` as the CLI-bin alias).
+
+**What the wizard does, in order:**
+
+1. **Detect installed clients.** Probe for `claude` and `code` on PATH (with fallbacks — see footguns), and for known config-file locations of Cursor/Windsurf/Claude Desktop. Present the detected set; let the user pick which to configure (default: all detected).
+2. **Acquire a token (API-token path, the default).** Open the browser to https://www.notion.so/my-integrations, instruct the user to create an internal integration and paste the token. **Validate it live with `get_me`** before writing it anywhere. Reject a token that doesn't authenticate.
+3. **Sane defaults.** Optionally capture a `NOTION_ROOT_PAGE_ID` (prompt, or skip). Optionally set up a CLI profile (`profiles.json`) — deferred to Phase 3.
+4. **Register into each chosen client** (mechanism per §4).
+5. **Verify end-to-end.** Run a live `get_me` to confirm the token authenticates. Then check for the *no-pages-shared* state. **Empty `search` is a warning, not proof** (Codex: database-only sharing and search-index quirks can yield an empty result for a correctly-shared workspace). So: if `search` is empty, surface "your token is valid but I couldn't see any shared pages — open a page → ••• → Connections → add your integration" as a *warning*, and offer the stronger check — ask the user to paste one page URL and retrieve it directly, which proves sharing deterministically.
+6. **Cookbook skill (optional, opt-in).** Offer to install the `notion-recipes` / `easy-notion-cli` skills into `~/.claude/skills/` for Claude Code users; for other clients, print the path and a docs pointer (see §6).
+7. **Report.** Print exactly what was configured, what was skipped, and any remaining manual step.
+
+**Non-interactive form (Phase 3):** `easy-notion init --client claude --token-env NOTION_TOKEN --yes` for scripted installs. Phase 1 is interactive-only.
+
+## 3. Target clients
+
+| Client | Mechanism available | v1 tier | Notes |
+|---|---|---|---|
+| **Claude Code** | `claude mcp add` / `get` / `list` CLI | **Phase 1** | Primary audience; the only client with idempotency primitives (`get`/`list`). |
+| **VS Code (Copilot)** | `code --add-mcp '{...}'` CLI | **Phase 2** | True shell-out CLI. Uses top-level `servers`, **not** `mcpServers`. |
+| **Cursor** | JSON deep-merge (`~/.cursor/mcp.json`) | **Phase 2** | No general CLI. Deep-link is README-button-only (needs a UI click). |
+| **Windsurf** | JSON deep-merge (`~/.codeium/windsurf/mcp_config.json`) | **Phase 2** | No CLI. |
+| **Claude Desktop** | JSON deep-merge (`claude_desktop_config.json`) | **Phase 2** | No CLI; Windows MSIX path bug; requires app restart. |
+| **claude.ai web connectors** | **None — architecturally impossible** | **Out of scope** | claude.ai connects from Anthropic's cloud to a *public HTTPS* endpoint with OAuth. A local stdio npm package can never be a claude.ai connector. Document this explicitly so it isn't mistaken for an oversight. |
+
+**v1 client decision:** Phase 1 ships **Claude Code only** (the project's primary audience, and the safest mechanism — delegate to a CLI that owns its own config format and gives us idempotency for free). Phase 2 adds the other four local clients. claude.ai is permanently out for a local-npx bootstrap.
+
+**Two corrections flagged by Codex review:**
+- **Existing-server name is `notion`, not `easy-notion-mcp`.** The current README registers Claude Code (`claude mcp add notion ...`, README:60) and the JSON examples (README:87, README:199) under the server key `notion` in some places and `easy-notion-mcp` in others. Idempotency detection therefore cannot key on a single fixed name — see §8.
+- **Windsurf config path is wrong in the current README.** Plan uses `~/.codeium/windsurf/mcp_config.json` (matches current Windsurf docs); README:98 still says `~/.windsurf/mcp.json`. The README needs correcting when Phase 2 lands (track as a Phase 2 doc task).
+
+## 4. Design space and recommendation
+
+Three mechanisms for getting the registration in place:
+
+### Approach A — Shell-out only
+Delegate to each client's own CLI where one exists (`claude mcp add`, `code --add-mcp`); print copy-paste blocks for the rest.
+- **Pro:** Never touches a user-owned JSON file → smallest footgun surface; idempotency and format-correctness are the client's problem.
+- **Con:** Only Claude Code and VS Code have CLIs. "One command" degrades to "one command for two clients, manual for Cursor/Windsurf/Desktop." Thin coverage.
+
+### Approach B — Direct JSON config writer
+Detect each client's config file and deep-merge an `easy-notion-mcp` entry.
+- **Pro:** Uniform coverage of every local client.
+- **Con:** Merging into hand-edited user files is the whole footgun catalogue — backups, atomic writes, not clobbering sibling servers, idempotent re-runs, the `servers` vs `mcpServers` divergence, cross-OS paths, the Claude Desktop MSIX path bug, restart prompts. Every one of these is a way to corrupt a user's working config.
+
+### Approach C — Hybrid *(recommended)*
+**Prefer the client's own CLI where one exists; fall back to guarded JSON deep-merge where it doesn't.** Claude Code → `claude mcp add`. VS Code → `code --add-mcp`. Cursor/Windsurf/Claude Desktop → JSON deep-merge with backup + atomic write + idempotency check + explicit pre-write confirmation showing the user the diff. **The shown diff must redact `env.NOTION_TOKEN`** (Codex caught the conflict with "never print the token" in §8) — show `NOTION_TOKEN: ntn_••••` not the value.
+- **Pro:** Broadest *real* coverage while using the safest available mechanism per client. The dangerous JSON-merge path is confined to the three clients that genuinely have no alternative, and is gated behind a shown-diff confirmation.
+- **Con:** Two code paths to maintain. Acceptable — they split cleanly along "has a CLI / doesn't."
+
+**Recommendation: Approach C, delivered in phases** — Phase 1 is purely the shell-out path for Claude Code (Approach A restricted to one client, zero JSON-file risk), which de-risks the wizard core. Phase 2 adds the JSON-merge path (the genuinely hard, footgun-heavy part) once the wizard skeleton is proven.
+
+**Tradeoff for human sign-off:** Phase 1 ships value to the primary audience (Claude Code) with essentially no risk of corrupting user config. The cost is that Cursor/Windsurf/Desktop users get nothing better than today's README until Phase 2. If broad-client coverage on day one matters more than shipping-safe-and-early, Phase 1 and 2 could merge — but that front-loads all the JSON-merge risk. **Recommend shipping Phase 1 first.**
+
+## 5. Contract impact
+
+This ships **fully additive**; nothing here touches the frozen 1.0 contract.
+
+- **MCP tool contract (frozen, additive-only):** untouched. No new tools, no schema changes, no return-shape changes, no markdown-convention or warning-code changes. The bootstrap is a CLI/entrypoint concern, not an MCP-surface concern. ✅
+- **`easy-notion` CLI:** explicitly **pre-1.0 and outside the freeze** (README "Stability and versioning"). A new `init` subcommand is doubly safe. ✅
+- **`npx easy-notion-mcp` (no args) hero command:** must keep working as a stdio server. "Byte-for-byte unchanged" was too strong (Codex). The **realistic, testable invariant** is: no-arg invocation (a) emits nothing on **stdout** except JSON-RPC, (b) reaches `server.connect`, (c) keeps current **stderr** behavior, and (d) requires no new env vars. The existing `tests/stdio-startup.test.ts` covers the baseline; Phase 1 adds (i) a no-arg protocol-handshake assertion and (ii) an `init`-without-`NOTION_TOKEN`-succeeds test (proving the branch runs before the token-required exit). **This is the single contract-adjacent risk.** ✅
+- **`profiles.json` schema:** Phase 3 may write it; the format is already established and any additions are additive. ✅
+- **New env vars:** none required. Reuse `EASY_NOTION_CONFIG_DIR`, `NOTION_TOKEN`, `NOTION_ROOT_PAGE_ID`.
+
+**Nothing in this plan requires a breaking change.** If a future iteration wanted to change the *default* behavior of `npx easy-notion-mcp` (no args) to run the wizard instead of the server, *that* would be breaking and is explicitly rejected here.
+
+## 6. Cookbook skill integration
+
+The npm tarball already ships `skills/` (`package.json` `files` includes `"skills"`), so `notion-recipes` and `easy-notion-cli` are present on disk wherever the package is installed. Bootstrap's role is to *surface* them, opt-in:
+
+- **Claude Code (Phase 1, pointer only):** after registration, print the on-disk skill path and how to use it; offer (y/N) to copy `skills/notion-recipes` and `skills/easy-notion-cli` into `~/.claude/skills/`.
+- **Actually copy into `~/.claude/skills/` (Phase 2):** with idempotency (don't overwrite a user-modified copy without asking).
+- **Other clients:** skills are a Claude-Code concept; just print a docs pointer.
+
+Keep this strictly optional. The bootstrap's headline job is registration + credential validation; the skill is a value-add, not a gate.
+
+## 7. Runtime premises
+
+This plan rests on external runtime behavior that training data can drift on. **Correction from Codex review:** these are **runtime** probes the wizard performs on the user's machine, *not* build-time/CI probes — CI machines have no authenticated `claude`/`code`/Cursor/Windsurf and no Notion token. The build's job is to **unit-test the probe-and-fallback logic with fakes**; genuine live probes belong in an opt-in integration harness (like the existing e2e harness), never in default CI.
+
+1. **`claude mcp add --scope user --transport stdio <name> -e KEY=VAL -- npx -y easy-notion-mcp` is the correct registration form.** Verified against current Claude Code docs (2026). *Runtime:* wizard runs `claude --version`/`claude mcp list` and degrades to a copy-paste block if the surface differs. *Build:* unit-test the command-construction + fallback with a fake exec.
+2. **`claude mcp get <name>` returns non-zero / empty on not-found.** Research notes this is the *expected* convention but **not formally documented**; idempotency depends on it. *Runtime:* the wizard tolerates both signals and falls back to parsing `claude mcp list`. *Live harness:* capture `claude mcp get nonexistent-xyz; echo $?` once to confirm; do not gate CI on it.
+3. **`code --add-mcp '{...}'` exists and accepts `{"name","command","args","env"}` (VS Code ≥1.102).** Verified via research. *Runtime:* probe `code --version` ≥ 1.102 before use; else JSON-merge `.vscode/mcp.json`.
+4. **Client config paths and the `servers` (VS Code) vs `mcpServers` (all others) key divergence are as tabled in §3.** Verified via research. *Build:* per-client path+key table in code with a unit test asserting VS Code uses `servers`; prefer shell-out so we lean on paths as little as possible.
+5. **`npx easy-notion-mcp` with no args still satisfies the stdio invariant (§5).** *Build:* extend `tests/stdio-startup.test.ts` with the handshake + `init`-without-token tests described in §5.
+6. **`get_me` proves the token; empty `search` does NOT prove no-pages-shared.** *Corrected per Codex:* `get_me` is a sufficient liveness check, but a valid-token-but-no-shared-pages state is only *suggested* by an empty `search`, not proven (database-only sharing, index lag). The deterministic check is retrieving a user-supplied page URL. *Live harness:* capture a probe (valid token, zero shared pages → `get_me` OK, `search` empty, direct page retrieve fails with the share hint) to confirm the warning + paste-URL flow fires correctly. Still the highest-value probe — no-pages-shared is the most common real-world dead-end.
+7. **`claude` / `code` binaries are NOT reliably on PATH in the non-interactive shell `npx` spawns.** Verified via research (documented gotcha incl. Windows installer PATH bug). *Runtime:* probe `which` + known install locations (`~/.local/bin/claude`, etc.); on miss, graceful skip + copy-paste, never a hard error.
+8. **`npx`/Node is reachable, a browser opener exists, and stdin is a TTY.** *(Added per Codex.)* GUI-launched MCP clients may run with a `PATH`/env that lacks Node; `open`/`xdg-open`/`start` may be absent; `npx easy-notion-mcp init` may be piped (no TTY). *Runtime:* detect TTY (fall back to printing instructions + URLs if absent), detect a browser opener (print the URL if none), and verify Node/npx is invocable for the *generated config* (warn if the registered `npx` won't resolve in the client's launch env).
+9. **First `npx easy-notion-mcp` cold-start can show a transient "failed to connect" while npm installs the package.** *(Added per Codex.)* The wizard's final "now restart your client" message must pre-empt this: tell the user the first connection may lag while the package downloads.
+10. **`NOTION_ROOT_PAGE_ID`, if provided, is a real page the integration can access.** *(Added per Codex.)* Don't accept it blindly — live-retrieve it and confirm access, else warn.
+11. **Generated-config package reference policy is a deliberate choice, not an accident.** *(Added per Codex; see open question §10.5.)* `easy-notion-mcp` (floating, always-fresh), `easy-notion-mcp@latest` (explicit fresh), or a pinned `easy-notion-mcp@X.Y.Z` (reproducible, but stale until re-run) behave differently. Pick one and document the trade.
+
+No premise here is "assumed from training data" — each maps to a runtime probe (with unit-tested fallback) or a captured live-harness probe.
+
+## 8. Risks and footguns
+
+- **Credential handling.** Never write the raw token to a shell rcfile or stdout/logs. Claude Code path: pass via `claude mcp add -e` (lives in Claude's own scoped config). JSON-merge path: the token *must* land in the client config file (that's where that client reads it from) — when we *create* the file, write mode `0600`; when merging into an existing file, preserve its perms and warn. **The shown diff/backup/temp files must all redact or protect the token** (Codex: the §4 "show the diff" and "never print the token" rules conflict — redact `NOTION_TOKEN` in the diff, and chmod backups/temp the same as the target). Validate via `get_me`, never by echoing.
+- **Token entry has no built-in no-echo (Codex).** `node:readline/promises` does not mask input by default, so a pasted token would be visible on screen and in scrollback. Mitigation: implement masked input manually (raw-mode stdin, suppress echo) — a real, non-trivial Phase 1 cost — or accept a prompt dependency that provides it. This sharpens open question §10.1.
+- **Idempotent re-run (Codex: cannot key on a single name).** Existing installs may have registered the server as `notion` *or* `easy-notion-mcp` (both appear in the current README). Detect by **server-key match OR (`command`/`args` pointing at the `easy-notion-mcp` package)**, then offer update/skip/replace. Claude Code: use `claude mcp get`/`list`. JSON-merge: update the matched entry in place; **never clobber sibling servers, and preserve unknown fields on our own entry** (client-specific keys like `type`, `enabled`, timeouts, headers, sandbox flags — merge only the fields we own: `command`, `args`, selected `env`).
+- **Atomic write needs more than temp+rename (Codex).** Write the temp file *adjacent* to the target (same filesystem, for atomic rename); `chmod` it before writing secret content; protect the `.bak` the same way; on POSIX `fsync` the file and best-effort the directory; on Windows handle the lock/`EPERM` case where a running GUI app holds the file open (retry/clear-message rather than corrupt).
+- **Restart semantics are per-client, not generic (Codex).** Surface the exact post-write action per client: Claude Code picks up config on a *new session*; VS Code may require starting/restarting the MCP server and accepting a *trust prompt*; Windsurf docs say *refresh* after adding; Claude Desktop must be *fully quit and relaunched*. Don't print a generic "restart your client."
+- **Partial-setup recovery.** Wizard is staged and each step reports independently; on any failure, print what succeeded and the exact manual command to finish the rest. No all-or-nothing rollback that could undo a good prior step.
+- **Cross-platform.** PATH detection per premise 7. Windows native: emit `cmd /c npx -y easy-notion-mcp` in generated configs (documented "Connection closed" workaround). Claude Desktop MSIX path lands under `%LOCALAPPDATA%\Packages\...` not `%APPDATA%` — handle both. WSL: home paths resolve fine, but a Windows-side `claude`/`code` may not be reachable from WSL and vice-versa; detect and say so rather than writing to the wrong side.
+- **The no-shared-pages dead-end.** Covered in §2 step 5 (and corrected: empty `search` is a *warning*, the paste-a-URL retrieve is the deterministic proof). The single most important UX guard.
+- **JSONC reality (Codex).** Real Cursor/VS Code configs may contain comments or trailing commas. A naive `JSON.parse`→`JSON.stringify` round-trip would silently delete them. Either use a comment-preserving JSONC editor, or **detect JSONC and refuse the auto-merge with precise manual instructions** rather than corrupt the file. (My research said "none use JSONC in practice"; Codex is right that this is too optimistic for VS Code — design for the safe failure.)
+- **npx staleness.** Document `@latest`; the wizard prints its own version so a stale run is visible. See also the generated-config package-ref policy (premise 11 / §10.5).
+- **Dependency tolerance.** The repo is deliberately dependency-lean (`marked`, `@notionhq/client`, `express`, `dotenv`). An interactive wizard wants a prompt library. **Recommendation: built-in `node:readline/promises`** to avoid a runtime dep — but note the no-echo cost above, which is the strongest argument for a small dep. → **Open question for human (§10.1).**
+
+## 9. Phasing and size
+
+- **Phase 1 — Wizard core + Claude Code (first buildable slice). Size: M (~2–4 days).** *Trimmed per Codex: the skill copy/pointer moves out of the core slice; manual-config-block generation (zero JSON-file risk) moves in to widen reach.*
+  - `init` entrypoint: lazy dynamic-import branch in `src/index.ts` (refactored into `main()`, before the token check) + `easy-notion init` dispatch case that calls the wizard directly (not through `runCli`'s JSON-write path).
+  - Interactive flow via `node:readline/promises` (with masked token entry): browser-open to integrations page, token entry, live `get_me` validation, optional **and validated** root-page-id.
+  - Claude Code registration via `claude mcp add` with name-or-package idempotency (`get`/`list`, handling the legacy `notion` name).
+  - End-to-end verify: `get_me` + the no-shared-pages warning + paste-a-URL deterministic check.
+  - **Breadth without risk:** for any *other* detected client, print a ready-to-paste config block (token redacted in any echoed/log copy) — no file writes. This gives Cursor/Windsurf/Desktop/VS Code users a real improvement in Phase 1 without the JSON-merge footguns.
+  - Tests: stdio invariant (handshake + `init`-without-token, §5); unit-test the probe/fallback and command-construction logic with fakes (§7).
+  - **Test focus:** the no-arg/`init` branch boundary (premise 5) and the live token-validation + no-shared-pages path (premise 6) — these cross the entrypoint and the Notion API boundary.
+
+- **Phase 2 — Multi-client JSON-merge + VS Code. Size: M–L (~4–6 days, mostly tests).**
+  - Guarded JSON deep-merge writer (backup, atomic write, idempotent, shown-diff confirmation) for Cursor/Windsurf/Claude Desktop.
+  - `code --add-mcp` for VS Code (with `servers`-key correctness).
+  - Client auto-detection across the OS path matrix.
+  - Cookbook skill: copy `notion-recipes`/`easy-notion-cli` into `~/.claude/skills/` (opt-in, idempotent) — moved here from Phase 1 per Codex trim.
+  - README correction: Windsurf path `~/.windsurf/mcp.json` → `~/.codeium/windsurf/mcp_config.json`.
+  - **Test focus:** the JSON-merge path against fixture configs (existing siblings to preserve, unknown fields to keep, missing file, **JSONC with comments/trailing commas → refuse-and-instruct**, re-run idempotency, token redaction in diffs) across macOS/Linux/Windows path shapes. This is where corruption bugs live.
+
+- **Phase 3 — Profiles, OAuth, non-interactive. Size: M (~2–3 days).**
+  - `init --profile` writing `profiles.json`.
+  - Guided OAuth/HTTP setup (on the experimental auth surface — keep clearly labeled experimental).
+  - `--yes` / fully-flagged non-interactive mode for scripted installs.
+
+## 10. Open questions (need human input)
+
+1. **Dependency tolerance for the prompt UX.** Built-in `node:readline/promises` (zero new deps, plainer UX, but **no built-in masked token entry** — we'd hand-roll raw-mode no-echo) vs a small prompt lib like `@clack/prompts` (nicer UX + masked input for free, but one more dependency on a package that handles a workspace token). *Recommendation: built-in + hand-rolled masking* — but the no-echo cost (Codex) is a legitimate reason to accept a vetted dep. — **human call (taste + supply-chain vs. implementation cost).**
+2. **Phase 1 client scope.** Ship Phase 1 Claude-Code-only (safe, primary audience) vs fold Phase 2 in for broad day-one coverage (front-loads JSON-merge risk). *Recommendation: Claude-Code-only first.* — **human call (reach vs risk).**
+3. **OAuth in scope at all?** OAuth would remove token copy-paste but needs a public HTTP deployment and sits on the experimental auth surface. *Recommendation: Phase 3, clearly labeled experimental; not a v1 goal.* — **human call (is OAuth onboarding a priority?).**
+4. **Skill auto-install default.** Should copying skills into `~/.claude/skills/` be opt-in (y/N default N) or opt-out? *Recommendation: opt-in.* — minor; human may override.
+5. **Generated-config package reference** *(added from Codex/premise 11).* Should registered configs invoke `easy-notion-mcp` (floating), `easy-notion-mcp@latest` (explicit fresh), or a pinned `easy-notion-mcp@X.Y.Z` (reproducible but stale until re-run)? *Recommendation: unpinned `easy-notion-mcp` in the config (clients re-resolve), `@latest` only for the one-shot `init` invocation itself.* — **human call (freshness vs reproducibility).**
+
+## 11. Cost
+
+**None.** No new paid infrastructure. The Notion API is free for the user's own integration token; registering a public OAuth integration (Phase 3) is also free. The only cost-adjacent note is the existing cookbook caveat that some database-query patterns assume the user's Notion plan limits — unchanged by this work. No pricing cliffs.
+
+---
+
+## Codex review
+
+Pressure-tested by Codex (high reasoning effort) via sync `mcp-cli run --agent codex`, session **`plan-review-one-command-bootstrap`** (Codex session id `019f0582-af5e-70f0-afe1-26fbc3c53ac7`). Codex independently re-read `src/index.ts`, `package.json`, `src/cli/run.ts`, `README.md` and re-checked current Claude Code / VS Code / Windsurf MCP docs. The review changed the plan materially — summary of what was adopted:
+
+| # | Codex finding | Disposition |
+|---|---|---|
+| 1 | "Show the diff" (§4) conflicts with "never print the token" (§8) | **Adopted** — diff/backups/temp now redact + protect the token (§4, §8). |
+| 2 | JSON-merge under-specified; real configs may be JSONC; naive parse/stringify corrupts | **Adopted** — detect JSONC and refuse-with-instructions rather than corrupt (§8, Phase 2 tests). |
+| 3 | Idempotency can't key only on `easy-notion-mcp`; README uses `notion` too | **Adopted** — detect by name *or* package in `command`/`args` (§3, §8). |
+| 4 | Must preserve unknown sibling/own fields on merge | **Adopted** — merge only fields we own (§8). |
+| 5 | Atomic write needs adjacent temp, chmod-first, protected `.bak`, fsync, Windows lock path | **Adopted** (§8). |
+| 6 | Restart semantics are per-client | **Adopted** — per-client post-write actions (§8). |
+| 7 | README Windsurf path wrong vs plan | **Adopted** — flagged + Phase 2 doc-fix task (§3, §9). |
+| 8 | `index.ts` builds server at top level; needs `main()` refactor + lazy `import` for `init`; don't route wizard through `runCli` JSON path | **Adopted** — rewrote the §2 entrypoint note. |
+| 9 | Several "build-time probes" must be **runtime** probes (CI has no creds) | **Adopted** — rewrote §7: runtime probes + unit-tested fakes + opt-in live harness. |
+| 10 | Missing premises: npx/Node-in-GUI-env, browser opener + TTY, cold-start transient failure, root-page-id live-validate, package-ref policy | **Adopted** — added premises 8–11 (§7) and open question §10.5. |
+| 11 | `readline/promises` has no masked input; visible token paste is a wart | **Adopted** — surfaced as a real Phase 1 cost; strengthened §10.1. |
+| 12 | Empty `search` is not proof of no-shared-pages | **Adopted** — downgraded to a warning; added paste-a-URL deterministic check (§2, §7). |
+| 13 | "Byte-for-byte unchanged" stdio claim too strong | **Adopted** — replaced with a precise, testable invariant citing `tests/stdio-startup.test.ts` (§5). |
+| — | MCP tool-contract additivity claim | **Confirmed true by Codex** (no tool schemas/return shapes change). |
+
+**Nothing was overruled.** Every Codex finding was either a correctness fix or a sharpening that aligned with the plan's goals (safe, honest, additive). The two judgment calls Codex left open — prompt dependency and Phase-1 scope — remain human decisions in §10, with the plan's recommendations unchanged but now better-argued (the no-echo cost on one side, the no-risk manual-config-block breadth play on the other).
+
+### Research provenance
+- Claude Code `claude mcp` CLI surface (add/get/list/remove, scopes, transports, PATH gotchas): general-purpose research agent, session `a1b3d92a04daad52a`.
+- Multi-client config landscape (Cursor/Windsurf/VS Code/Claude Desktop paths + keys; claude.ai-connector infeasibility): general-purpose research agent, session `a50229bbb19b0594b`.
+- Plan pressure-test: Codex, session `plan-review-one-command-bootstrap`.

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -44,6 +44,7 @@ export type InitDeps = {
 };
 
 const SERVER_NAME = "easy-notion-mcp";
+const TOKEN_PLACEHOLDER = "<paste-your-notion-token-here>";
 const TOKEN_URL = "https://www.notion.so/my-integrations";
 const SKILL_NAMES = ["notion-recipes", "easy-notion-cli"] as const;
 
@@ -383,8 +384,8 @@ async function checkSharedPages(deps: InitDeps, client: NotionProbe) {
   }
 }
 
-function manualConfig(command: string, token: string, rootPageId?: string) {
-  const env: Record<string, string> = { NOTION_TOKEN: token };
+function manualConfig(command: string, rootPageId?: string) {
+  const env: Record<string, string> = { NOTION_TOKEN: TOKEN_PLACEHOLDER };
   if (rootPageId) {
     env.NOTION_ROOT_PAGE_ID = rootPageId;
   }
@@ -395,16 +396,17 @@ function manualConfig(command: string, token: string, rootPageId?: string) {
   };
 }
 
-function printManualBlocks(deps: InitDeps, token: string, rootPageId?: string) {
+function printManualBlocks(deps: InitDeps, rootPageId?: string) {
   const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
   const mcpServers = {
-    [SERVER_NAME]: manualConfig(npxCommand, token, rootPageId),
+    [SERVER_NAME]: manualConfig(npxCommand, rootPageId),
   };
   const servers = {
-    [SERVER_NAME]: manualConfig(npxCommand, token, rootPageId),
+    [SERVER_NAME]: manualConfig(npxCommand, rootPageId),
   };
 
-  writeLine(deps, "The blocks below contain your Notion token. Treat them as a secret and do not commit them to source control.");
+  writeLine(deps, `Replace ${TOKEN_PLACEHOLDER} with your actual Notion token in the blocks below.`);
+  writeLine(deps, "Treat your Notion token as a secret and do not commit these blocks to source control.");
   writeLine(deps, "Cursor");
   writeLine(deps, JSON.stringify({ mcpServers }, null, 2));
   writeLine(deps, "Windsurf");
@@ -496,7 +498,7 @@ export async function runInit(args: string[], partialDeps?: Partial<InitDeps>): 
   }
 
   await checkSharedPages(deps, validation.client);
-  printManualBlocks(deps, token, rootPageId);
+  printManualBlocks(deps, rootPageId);
   await installSkills(deps);
 
   writeLine(deps, "Restart Claude Code or start a new session to pick up the user-scope MCP config.");

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -269,7 +269,9 @@ async function detectClaude(deps: InitDeps) {
 
 async function promptForToken(deps: InitDeps) {
   try {
-    await deps.openBrowser(TOKEN_URL);
+    if (deps.isTTY) {
+      await deps.openBrowser(TOKEN_URL);
+    }
   } catch {
     // Browser opening is best effort. The printed prompt still gives the URL.
   }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,505 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import { stdin as processStdin, stdout as processStdout } from "node:process";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import * as fsPromises from "node:fs/promises";
+import { createNotionClient, getMe, getPage, searchNotion } from "../notion-client.js";
+import { notionUrlToPageId } from "../markdown-to-blocks.js";
+
+export type NotionProbe = {
+  getMe(): Promise<unknown>;
+  search(query: string, filter?: "pages" | "databases"): Promise<unknown[]>;
+  getPage(id: string): Promise<unknown>;
+};
+
+export type InitFs = {
+  exists(path: string): Promise<boolean>;
+  mkdir(path: string, opts?: { recursive?: boolean }): Promise<void>;
+  readdir(path: string, opts?: { withFileTypes?: boolean }): Promise<any[]>;
+  readFile(path: string): Promise<Buffer | string>;
+  writeFile(path: string, data: string | Buffer): Promise<void>;
+  rename(oldPath: string, newPath: string): Promise<void>;
+  rm(path: string, opts?: { recursive?: boolean; force?: boolean }): Promise<void>;
+  stat(path: string): Promise<{ isDirectory(): boolean }>;
+};
+
+export type InitDeps = {
+  io: {
+    stdout: { write(str: string): unknown };
+    stderr: { write(str: string): unknown };
+  };
+  prompt(question: string, opts?: { mask?: boolean }): Promise<string>;
+  confirm(question: string, defaultNo: boolean): Promise<boolean>;
+  which(bin: string): Promise<string | null>;
+  exec(cmd: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }>;
+  openBrowser(url: string): Promise<void>;
+  createClient(token: string): NotionProbe;
+  fs: InitFs;
+  skillsSourceDir: string;
+  skillsTargetDir: string;
+  isTTY: boolean;
+  env: Record<string, string>;
+};
+
+const SERVER_NAME = "easy-notion-mcp";
+const TOKEN_URL = "https://www.notion.so/my-integrations";
+const SKILL_NAMES = ["notion-recipes", "easy-notion-cli"] as const;
+
+function defaultSkillsSourceDir() {
+  return fileURLToPath(new URL("../../skills/", import.meta.url));
+}
+
+function defaultSkillsTargetDir() {
+  return join(homedir(), ".claude", "skills");
+}
+
+function defaultFs(): InitFs {
+  return {
+    exists: async (path) => {
+      try {
+        await fsPromises.stat(path);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    mkdir: async (path, opts) => {
+      await fsPromises.mkdir(path, opts);
+    },
+    readdir: (path, opts) => fsPromises.readdir(path, opts as any) as Promise<any[]>,
+    readFile: (path) => fsPromises.readFile(path),
+    writeFile: (path, data) => fsPromises.writeFile(path, data),
+    rename: (oldPath, newPath) => fsPromises.rename(oldPath, newPath),
+    rm: (path, opts) => fsPromises.rm(path, opts),
+    stat: (path) => fsPromises.stat(path),
+  };
+}
+
+function execFile(cmd: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      resolve({ code: 127, stdout, stderr: error.message });
+    });
+    child.on("close", (code) => {
+      resolve({ code: code ?? 0, stdout, stderr });
+    });
+  });
+}
+
+async function which(bin: string) {
+  const command = process.platform === "win32" ? "where" : "which";
+  const result = await execFile(command, [bin]);
+  if (result.code !== 0) {
+    return null;
+  }
+  return result.stdout.split(/\r?\n/).find(Boolean) ?? null;
+}
+
+async function openBrowser(url: string) {
+  const cmd = process.platform === "darwin"
+    ? "open"
+    : process.platform === "win32"
+      ? "cmd"
+      : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  await execFile(cmd, args);
+}
+
+async function plainPrompt(question: string) {
+  if (!processStdin.isTTY) {
+    processStdout.write(question);
+    return "";
+  }
+  const rl = createInterface({ input: processStdin, output: processStdout });
+  try {
+    return await rl.question(question);
+  } finally {
+    rl.close();
+  }
+}
+
+async function maskedPrompt(question: string) {
+  if (!processStdin.isTTY || typeof processStdin.setRawMode !== "function") {
+    return plainPrompt(question);
+  }
+
+  processStdout.write(question);
+  processStdin.setRawMode(true);
+  processStdin.resume();
+  processStdin.setEncoding("utf8");
+
+  return await new Promise<string>((resolve) => {
+    let value = "";
+    const cleanup = () => {
+      processStdin.setRawMode(false);
+      processStdin.pause();
+      processStdin.off("data", onData);
+      processStdout.write("\n");
+    };
+    const onData = (chunk: string) => {
+      for (const char of chunk) {
+        if (char === "\u0003") {
+          cleanup();
+          resolve("");
+          return;
+        }
+        if (char === "\r" || char === "\n") {
+          cleanup();
+          resolve(value);
+          return;
+        }
+        if (char === "\u007f" || char === "\b") {
+          value = value.slice(0, -1);
+          continue;
+        }
+        value += char;
+      }
+    };
+    processStdin.on("data", onData);
+  });
+}
+
+async function defaultPrompt(question: string, opts?: { mask?: boolean }) {
+  return opts?.mask ? maskedPrompt(question) : plainPrompt(question);
+}
+
+async function defaultConfirm(question: string, defaultNo: boolean) {
+  const suffix = defaultNo ? " [y/N] " : " [Y/n] ";
+  const answer = (await plainPrompt(`${question}${suffix}`)).trim().toLowerCase();
+  if (!answer) {
+    return !defaultNo;
+  }
+  return answer === "y" || answer === "yes";
+}
+
+function defaultCreateClient(token: string): NotionProbe {
+  const client = createNotionClient(token);
+  return {
+    getMe: () => getMe(client),
+    search: (query, filter) => searchNotion(client, query, filter),
+    getPage: (id) => getPage(client, id),
+  };
+}
+
+function createDefaultDeps(partial: Partial<InitDeps> = {}): InitDeps {
+  return {
+    io: {
+      stdout: process.stdout,
+      stderr: process.stderr,
+    },
+    prompt: defaultPrompt,
+    confirm: defaultConfirm,
+    which,
+    exec: execFile,
+    openBrowser,
+    createClient: defaultCreateClient,
+    fs: defaultFs(),
+    skillsSourceDir: defaultSkillsSourceDir(),
+    skillsTargetDir: defaultSkillsTargetDir(),
+    isTTY: Boolean(process.stdin.isTTY),
+    env: process.env as Record<string, string>,
+    ...partial,
+  };
+}
+
+function parseArgs(args: string[]) {
+  let rootPageId: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--root-page-id") {
+      rootPageId = args[index + 1];
+      index += 1;
+    }
+  }
+  return { rootPageId };
+}
+
+function writeLine(deps: InitDeps, message = "") {
+  deps.io.stdout.write(`${message}\n`);
+}
+
+function knownClaudePaths(env: Record<string, string>) {
+  const localAppData = env.LOCALAPPDATA;
+  return [
+    join(homedir(), ".local", "bin", "claude"),
+    "/usr/local/bin/claude",
+    "/opt/homebrew/bin/claude",
+    ...(localAppData
+      ? [
+          join(localAppData, "Programs", "Claude", "claude.exe"),
+          join(localAppData, "AnthropicClaude", "claude.exe"),
+        ]
+      : []),
+  ];
+}
+
+async function detectClaude(deps: InitDeps) {
+  const fromPath = await deps.which("claude");
+  if (fromPath) {
+    writeLine(deps, "Claude Code detected");
+    return true;
+  }
+
+  for (const path of knownClaudePaths(deps.env)) {
+    try {
+      if (await deps.fs.exists(path)) {
+        writeLine(deps, "Claude Code detected");
+        return true;
+      }
+    } catch {
+      // Ignore probe failures. Detection is best effort.
+    }
+  }
+
+  writeLine(deps, "Claude Code was not detected");
+  return false;
+}
+
+async function promptForToken(deps: InitDeps) {
+  try {
+    await deps.openBrowser(TOKEN_URL);
+  } catch {
+    // Browser opening is best effort. The printed prompt still gives the URL.
+  }
+  writeLine(deps, `Create or open your Notion integration token: ${TOKEN_URL}`);
+  return (await deps.prompt("Enter your Notion token: ", { mask: deps.isTTY })).trim();
+}
+
+async function validateToken(deps: InitDeps, token: string) {
+  const client = deps.createClient(token);
+  try {
+    await client.getMe();
+    writeLine(deps, "Notion token is valid");
+    return { ok: true as const, client };
+  } catch {
+    writeLine(deps, "Invalid Notion token or authentication failed");
+    return { ok: false as const, client };
+  }
+}
+
+async function resolveRootPageId(deps: InitDeps, client: NotionProbe, cliRootPageId?: string) {
+  const prompted = cliRootPageId ? "" : (await deps.prompt("Optional root page id: ")).trim();
+  const rootPageId = cliRootPageId ?? prompted;
+  if (!rootPageId) {
+    return undefined;
+  }
+
+  try {
+    await client.getPage(rootPageId);
+    writeLine(deps, "Root page access confirmed");
+    return rootPageId;
+  } catch {
+    writeLine(deps, "WARNING: root page could not be accessed. Continuing without a root page.");
+    return undefined;
+  }
+}
+
+function parseOurRegistration(line: string) {
+  const [rawName, ...rest] = line.split(":");
+  const name = rawName.trim();
+  const command = rest.join(":");
+  if (name === SERVER_NAME || name === "notion" || command.includes(SERVER_NAME)) {
+    return name;
+  }
+  return null;
+}
+
+function claudeAddArgs(token: string, rootPageId?: string) {
+  return [
+    "mcp",
+    "add",
+    "--scope",
+    "user",
+    "--transport",
+    "stdio",
+    SERVER_NAME,
+    "-e",
+    `NOTION_TOKEN=${token}`,
+    ...(rootPageId ? ["-e", `NOTION_ROOT_PAGE_ID=${rootPageId}`] : []),
+    "--",
+    "npx",
+    "-y",
+    "easy-notion-mcp",
+  ];
+}
+
+async function registerClaude(deps: InitDeps, token: string, rootPageId?: string) {
+  const list = await deps.exec("claude", ["mcp", "list"]);
+  const existing = list.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim() ? parseOurRegistration(line) : null)
+    .find((name): name is string => Boolean(name));
+  if (existing) {
+    const replace = await deps.confirm(`An existing easy-notion-mcp registration was found (${existing}). Replace it?`, true);
+    if (!replace) {
+      writeLine(deps, "Existing Claude Code registration found. Skipping duplicate add.");
+      return;
+    }
+
+    await deps.exec("claude", ["mcp", "remove", existing, "-s", "user"]);
+    await deps.exec("claude", claudeAddArgs(token, rootPageId));
+    writeLine(deps, "Replaced existing Claude Code registration");
+    return;
+  }
+
+  await deps.exec("claude", claudeAddArgs(token, rootPageId));
+  writeLine(deps, "Claude Code registration complete");
+}
+
+async function checkSharedPages(deps: InitDeps, client: NotionProbe) {
+  const results = await client.search("");
+  if (results.length > 0) {
+    return;
+  }
+
+  writeLine(deps, "WARNING: no shared pages found. Share pages with your Notion integration.");
+  const url = (await deps.prompt("Paste a Notion page URL to check sharing, or press enter to skip: ")).trim();
+  if (!url) {
+    return;
+  }
+
+  const pageId = notionUrlToPageId(url);
+  if (!pageId) {
+    writeLine(deps, "Share the page with your integration, then rerun this check.");
+    return;
+  }
+
+  try {
+    await client.getPage(pageId);
+    writeLine(deps, "sharing confirmed");
+  } catch {
+    writeLine(deps, "Share the page with your integration, then rerun this check.");
+  }
+}
+
+function manualConfig(command: string, token: string, rootPageId?: string) {
+  const env: Record<string, string> = { NOTION_TOKEN: token };
+  if (rootPageId) {
+    env.NOTION_ROOT_PAGE_ID = rootPageId;
+  }
+  return {
+    command,
+    args: ["-y", "easy-notion-mcp"],
+    env,
+  };
+}
+
+function printManualBlocks(deps: InitDeps, token: string, rootPageId?: string) {
+  const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
+  const mcpServers = {
+    [SERVER_NAME]: manualConfig(npxCommand, token, rootPageId),
+  };
+  const servers = {
+    [SERVER_NAME]: manualConfig(npxCommand, token, rootPageId),
+  };
+
+  writeLine(deps, "The blocks below contain your Notion token. Treat them as a secret and do not commit them to source control.");
+  writeLine(deps, "Cursor");
+  writeLine(deps, JSON.stringify({ mcpServers }, null, 2));
+  writeLine(deps, "Windsurf");
+  writeLine(deps, JSON.stringify({ mcpServers }, null, 2));
+  writeLine(deps, "Claude Desktop");
+  writeLine(deps, JSON.stringify({ mcpServers }, null, 2));
+  writeLine(deps, "VS Code");
+  writeLine(deps, JSON.stringify({ servers }, null, 2));
+}
+
+async function copyDirAtomic(deps: InitDeps, source: string, target: string) {
+  const parent = dirname(target);
+  const temp = join(parent, `.tmp-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+  await deps.fs.rm(temp, { recursive: true, force: true });
+  await deps.fs.mkdir(temp, { recursive: true });
+
+  async function copyInto(src: string, dest: string) {
+    await deps.fs.mkdir(dest, { recursive: true });
+    const entries = await deps.fs.readdir(src, { withFileTypes: true });
+    for (const entry of entries) {
+      const name = typeof entry.name === "string" ? entry.name : String(entry);
+      const srcPath = join(src, name);
+      const destPath = join(dest, name);
+      const isDirectory = typeof entry.isDirectory === "function"
+        ? entry.isDirectory()
+        : (await deps.fs.stat(srcPath)).isDirectory();
+      if (isDirectory) {
+        await copyInto(srcPath, destPath);
+      } else {
+        const data = await deps.fs.readFile(srcPath);
+        await deps.fs.writeFile(destPath, data);
+      }
+    }
+  }
+
+  try {
+    await copyInto(source, temp);
+    await deps.fs.rm(target, { recursive: true, force: true });
+    await deps.fs.rename(temp, target);
+  } catch (error) {
+    await deps.fs.rm(temp, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function installSkills(deps: InitDeps) {
+  const shouldInstall = await deps.confirm("Install bundled Notion skills?", true);
+  if (!shouldInstall) {
+    return;
+  }
+
+  await deps.fs.mkdir(deps.skillsTargetDir, { recursive: true });
+  for (const skill of SKILL_NAMES) {
+    const source = join(deps.skillsSourceDir, skill);
+    const target = join(deps.skillsTargetDir, skill);
+    if (await deps.fs.exists(target)) {
+      const overwrite = await deps.confirm(`${skill} already exists. Overwrite or replace it?`, true);
+      if (!overwrite) {
+        continue;
+      }
+    }
+    await copyDirAtomic(deps, source, target);
+    writeLine(deps, `Installed skill ${skill}`);
+  }
+}
+
+export async function runInit(args: string[], partialDeps?: Partial<InitDeps>): Promise<number> {
+  const deps = createDefaultDeps(partialDeps);
+  const { rootPageId: cliRootPageId } = parseArgs(args);
+
+  writeLine(deps, "easy-notion init wizard");
+
+  const claudeDetected = await detectClaude(deps);
+  const token = await promptForToken(deps);
+  if (!token) {
+    writeLine(deps, "Invalid Notion token or authentication failed");
+    return 1;
+  }
+  const validation = await validateToken(deps, token);
+  if (!validation.ok) {
+    return 1;
+  }
+
+  const rootPageId = await resolveRootPageId(deps, validation.client, cliRootPageId);
+
+  if (claudeDetected) {
+    await registerClaude(deps, token, rootPageId);
+  }
+
+  await checkSharedPages(deps, validation.client);
+  printManualBlocks(deps, token, rootPageId);
+  await installSkills(deps);
+
+  writeLine(deps, "Restart Claude Code or start a new session to pick up the user-scope MCP config.");
+  writeLine(deps, "First run may be slower while npx downloads the package.");
+  return 0;
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -2024,6 +2024,11 @@ export async function runCli(
   partialIo: Partial<CliIO> = {},
   deps: CliDeps = {},
 ): Promise<number> {
+  if (argv[0] === "init" || argv[0] === "setup") {
+    const { runInit } = await import("./init.js");
+    return runInit(argv.slice(1));
+  }
+
   const io: CliIO = {
     stdout: process.stdout,
     stderr: process.stderr,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,24 +4,30 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createNotionClient } from "./notion-client.js";
 import { createServer } from "./server.js";
 
-const NOTION_TOKEN = process.env.NOTION_TOKEN;
-if (!NOTION_TOKEN) {
-  console.error("NOTION_TOKEN is required");
-  process.exit(1);
-}
-
-const notion = createNotionClient(NOTION_TOKEN);
-const server = createServer(
-  () => notion,
-  {
-    rootPageId: process.env.NOTION_ROOT_PAGE_ID,
-    trustContent: process.env.NOTION_TRUST_CONTENT === "true",
-    transport: "stdio",
-    workspaceRoot: process.env.NOTION_MCP_WORKSPACE_ROOT || process.cwd(),
-  }
-);
-
 async function main() {
+  const argv = process.argv.slice(2);
+  if (argv[0] === "init" || argv[0] === "setup") {
+    const { runInit } = await import("./cli/init.js");
+    process.exit(await runInit(argv.slice(1)));
+  }
+
+  const NOTION_TOKEN = process.env.NOTION_TOKEN;
+  if (!NOTION_TOKEN) {
+    console.error("NOTION_TOKEN is required");
+    process.exit(1);
+  }
+
+  const notion = createNotionClient(NOTION_TOKEN);
+  const server = createServer(
+    () => notion,
+    {
+      rootPageId: process.env.NOTION_ROOT_PAGE_ID,
+      trustContent: process.env.NOTION_TRUST_CONTENT === "true",
+      transport: "stdio",
+      workspaceRoot: process.env.NOTION_MCP_WORKSPACE_ROOT || process.cwd(),
+    }
+  );
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error(

--- a/tests/http-bin-startup.test.ts
+++ b/tests/http-bin-startup.test.ts
@@ -9,6 +9,8 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 let tempDir: string | undefined;
 let symlinkPath: string;
 let port: number;
+// Full-suite parallel spawn/import load can exceed the old 12s startup window; this is not a server regression.
+const STARTUP_TIMEOUT_MS = 30_000;
 
 function waitForStartupMessage(
   child: ChildProcessWithoutNullStreams,
@@ -20,7 +22,7 @@ function waitForStartupMessage(
     const timeout = setTimeout(() => {
       cleanup();
       reject(new Error(`Timed out waiting for startup message. stderr:\n${stderr}`));
-    }, 12_000);
+    }, STARTUP_TIMEOUT_MS);
 
     const onData = (chunk: Buffer | string) => {
       stderr += chunk.toString();
@@ -112,5 +114,5 @@ describe("HTTP bin-shim startup", () => {
     } finally {
       await stopChildProcess(child);
     }
-  }, 20_000);
+  }, 45_000);
 });

--- a/tests/init-wizard.test.ts
+++ b/tests/init-wizard.test.ts
@@ -283,6 +283,20 @@ describe("init wizard", () => {
     expect(io.output).toMatch(/invalid|auth|token/i);
   });
 
+  it("only opens the token URL in TTY mode while always printing it", async () => {
+    const runInit = await loadRunInit();
+    const tokenUrl = "https://www.notion.so/my-integrations";
+
+    const nonTty = await createDeps({ isTTY: false });
+    await expect(runInit([], nonTty.deps)).resolves.toBe(0);
+    expect(nonTty.openBrowserCalls).toHaveLength(0);
+    expect(nonTty.io.output).toContain(tokenUrl);
+
+    const tty = await createDeps({ isTTY: true });
+    await expect(runInit([], tty.deps)).resolves.toBe(0);
+    expect(tty.openBrowserCalls).toContain(tokenUrl);
+  });
+
   it("detects a legacy notion registration that points at this package and does not add a duplicate", async () => {
     const runInit = await loadRunInit();
     const { deps, confirmCalls, execCalls } = await createDeps({

--- a/tests/init-wizard.test.ts
+++ b/tests/init-wizard.test.ts
@@ -1,0 +1,529 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { notionUrlToPageId } from "../src/markdown-to-blocks.js";
+
+type ExecCall = {
+  cmd: string;
+  args: string[];
+};
+
+type NotionProbe = {
+  getMe: ReturnType<typeof vi.fn>;
+  search: ReturnType<typeof vi.fn>;
+  getPage: ReturnType<typeof vi.fn>;
+};
+
+type InitFs = {
+  exists(path: string): Promise<boolean>;
+  mkdir(path: string, opts?: { recursive?: boolean }): Promise<void>;
+  readdir(path: string, opts?: { withFileTypes?: boolean }): Promise<any[]>;
+  readFile(path: string): Promise<Buffer | string>;
+  writeFile(path: string, data: string | Buffer): Promise<void>;
+  rename(oldPath: string, newPath: string): Promise<void>;
+  rm(path: string, opts?: { recursive?: boolean; force?: boolean }): Promise<void>;
+  stat(path: string): Promise<{ isDirectory(): boolean }>;
+};
+
+type InitDeps = {
+  io: {
+    stdout: { write(str: string): unknown };
+    stderr: { write(str: string): unknown };
+  };
+  prompt(question: string, opts?: { mask?: boolean }): Promise<string>;
+  confirm(question: string, defaultNo: boolean): Promise<boolean>;
+  which(bin: string): Promise<string | null>;
+  exec(cmd: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }>;
+  openBrowser(url: string): Promise<void>;
+  createClient(token: string): NotionProbe;
+  fs: InitFs;
+  skillsSourceDir: string;
+  skillsTargetDir: string;
+  isTTY: boolean;
+  env: Record<string, string>;
+};
+
+type InitOverrides = Partial<Omit<InitDeps, "io" | "createClient">> & {
+  notion?: Partial<NotionProbe>;
+  answers?: Record<string, string>;
+  confirms?: Record<string, boolean>;
+  createClient?: InitDeps["createClient"];
+};
+
+const tempDirs: string[] = [];
+
+async function loadRunInit() {
+  const mod = await import("../src/cli/init.js");
+  return mod.runInit as (args: string[], deps?: InitDeps) => Promise<number>;
+}
+
+async function makeTempDir(prefix = "easy-notion-init-") {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function makeSkillSourceDir() {
+  const root = await makeTempDir("easy-notion-skills-src-");
+  await mkdir(join(root, "notion-recipes"), { recursive: true });
+  await mkdir(join(root, "easy-notion-cli"), { recursive: true });
+  await writeFile(join(root, "notion-recipes", "SKILL.md"), "# Notion recipes\n");
+  await writeFile(join(root, "easy-notion-cli", "SKILL.md"), "# Easy Notion CLI\n");
+  return root;
+}
+
+function createIo() {
+  let stdout = "";
+  let stderr = "";
+  return {
+    io: {
+      stdout: { write: (chunk: string) => { stdout += chunk; } },
+      stderr: { write: (chunk: string) => { stderr += chunk; } },
+    },
+    get stdout() {
+      return stdout;
+    },
+    get stderr() {
+      return stderr;
+    },
+    get output() {
+      return `${stdout}\n${stderr}`;
+    },
+  };
+}
+
+function createFs(overrides: Partial<InitFs> = {}): InitFs {
+  return {
+    exists: vi.fn(async (path: string) => {
+      try {
+        await stat(path);
+        return true;
+      } catch {
+        return false;
+      }
+    }),
+    mkdir: vi.fn(async (path: string, opts?: { recursive?: boolean }) => {
+      await mkdir(path, opts);
+    }),
+    readdir: vi.fn(async (path: string, opts?: { withFileTypes?: boolean }) => readdir(path, opts as any)),
+    readFile: vi.fn(async (path: string) => readFile(path)),
+    writeFile: vi.fn(async (path: string, data: string | Buffer) => {
+      await writeFile(path, data);
+    }),
+    rename: vi.fn(async (oldPath: string, newPath: string) => {
+      await import("node:fs/promises").then((fs) => fs.rename(oldPath, newPath));
+    }),
+    rm: vi.fn(async (path: string, opts?: { recursive?: boolean; force?: boolean }) => {
+      await rm(path, opts);
+    }),
+    stat: vi.fn(async (path: string) => stat(path)),
+    ...overrides,
+  };
+}
+
+async function createDeps(overrides: InitOverrides = {}) {
+  const {
+    answers: answerOverrides,
+    confirms: confirmOverrides,
+    createClient: createClientOverride,
+    exec: execOverride,
+    notion: notionOverrides,
+    ...depOverrides
+  } = overrides;
+  const io = createIo();
+  const promptCalls: Array<{ question: string; opts?: { mask?: boolean } }> = [];
+  const confirmCalls: Array<{ question: string; defaultNo: boolean }> = [];
+  const execCalls: ExecCall[] = [];
+  const openBrowserCalls: string[] = [];
+  const skillsSourceDir = overrides.skillsSourceDir ?? await makeSkillSourceDir();
+  const skillsTargetDir = overrides.skillsTargetDir ?? await makeTempDir("easy-notion-skills-target-");
+  const notion: NotionProbe = {
+    getMe: vi.fn(async () => ({ id: "bot-1", type: "bot", name: "Easy Notion" })),
+    search: vi.fn(async () => [{ id: "page-1", object: "page" }]),
+    getPage: vi.fn(async (id: string) => ({ id, object: "page" })),
+    ...notionOverrides,
+  };
+  const answers = {
+    token: "secret_notion_token",
+    root: "",
+    url: "",
+    ...answerOverrides,
+  };
+  const confirms = {
+    skill: false,
+    manual: true,
+    overwrite: false,
+    existing: false,
+    ...confirmOverrides,
+  };
+  const deps: InitDeps = {
+    io: io.io,
+    prompt: vi.fn(async (question: string, opts?: { mask?: boolean }) => {
+      promptCalls.push({ question, opts });
+      if (/token/i.test(question)) return answers.token;
+      if (/root/i.test(question)) return answers.root;
+      if (/url|paste|page/i.test(question)) return answers.url;
+      return "";
+    }),
+    confirm: vi.fn(async (question: string, defaultNo: boolean) => {
+      confirmCalls.push({ question, defaultNo });
+      if (/skill/i.test(question)) return confirms.skill;
+      if (/registration|registered/i.test(question) && /existing|replace/i.test(question)) return confirms.existing;
+      if (/overwrite|replace|already exists/i.test(question)) return confirms.overwrite;
+      if (/already registered|existing|update|replace|skip/i.test(question)) return confirms.existing;
+      if (/manual|other client|cursor|windsurf|desktop|vs code/i.test(question)) return confirms.manual;
+      return false;
+    }),
+    which: vi.fn(async () => "/path/claude"),
+    exec: vi.fn(async (cmd: string, args: string[]) => {
+      execCalls.push({ cmd, args });
+      if (execOverride) {
+        return execOverride(cmd, args);
+      }
+      if (cmd === "claude" && args.join(" ") === "mcp list") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    }),
+    openBrowser: vi.fn(async (url: string) => {
+      openBrowserCalls.push(url);
+    }),
+    createClient: createClientOverride ?? vi.fn(() => notion),
+    fs: createFs(),
+    skillsSourceDir,
+    skillsTargetDir,
+    isTTY: true,
+    env: {},
+    ...depOverrides,
+  };
+  deps.io = io.io;
+  return { deps, io, notion, promptCalls, confirmCalls, execCalls, openBrowserCalls };
+}
+
+function addCalls(calls: ExecCall[]) {
+  return calls.filter((call) => call.cmd === "claude" && call.args[0] === "mcp" && call.args[1] === "add");
+}
+
+function clientSection(output: string, label: string) {
+  const labels = ["Cursor", "Windsurf", "Claude Desktop", "VS Code"];
+  const start = output.search(new RegExp(label, "i"));
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = labels
+    .filter((candidate) => candidate !== label)
+    .map((candidate) => output.slice(start + label.length).search(new RegExp(candidate, "i")))
+    .filter((index) => index >= 0)
+    .map((index) => start + label.length + index)
+    .sort((a, b) => a - b)[0] ?? output.length;
+  return output.slice(start, end);
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("init wizard", () => {
+  it("detects Claude Code from PATH, known locations, or reports not detected without throwing", async () => {
+    const runInit = await loadRunInit();
+
+    const pathHit = await createDeps({
+      which: vi.fn(async () => "/path/claude"),
+    });
+    await expect(runInit([], pathHit.deps)).resolves.toBe(0);
+    expect(pathHit.io.output).toMatch(/Claude Code detected/i);
+
+    const knownLocationHit = await createDeps({
+      which: vi.fn(async () => null),
+      fs: createFs({
+        exists: vi.fn(async (path: string) => path.toLowerCase().includes("claude")),
+      }),
+    });
+    await expect(runInit([], knownLocationHit.deps)).resolves.toBe(0);
+    expect(knownLocationHit.io.output).toMatch(/Claude Code detected/i);
+
+    const miss = await createDeps({
+      which: vi.fn(async () => null),
+      fs: createFs({ exists: vi.fn(async () => false) }),
+    });
+    await expect(runInit([], miss.deps)).resolves.toBe(0);
+    expect(miss.io.output).toMatch(/Claude Code.*not detected/i);
+  });
+
+  it("accepts a token after live getMe validation succeeds", async () => {
+    const runInit = await loadRunInit();
+    const { deps, io, notion } = await createDeps();
+
+    await expect(runInit([], deps)).resolves.toBe(0);
+
+    expect(deps.createClient).toHaveBeenCalledWith("secret_notion_token");
+    expect(notion.getMe).toHaveBeenCalledOnce();
+    expect(io.output).toMatch(/token.*valid/i);
+  });
+
+  it("rejects a token when live getMe validation fails and does not register the server", async () => {
+    const runInit = await loadRunInit();
+    const { deps, io, notion, execCalls } = await createDeps({
+      notion: {
+        getMe: vi.fn(async () => {
+          throw new Error("unauthorized");
+        }),
+      },
+    });
+
+    await expect(runInit([], deps)).resolves.not.toBe(0);
+
+    expect(notion.getMe).toHaveBeenCalled();
+    expect(addCalls(execCalls)).toHaveLength(0);
+    expect(io.output).toMatch(/invalid|auth|token/i);
+  });
+
+  it("detects a legacy notion registration that points at this package and does not add a duplicate", async () => {
+    const runInit = await loadRunInit();
+    const { deps, confirmCalls, execCalls } = await createDeps({
+      exec: vi.fn(async (cmd: string, args: string[]) => {
+        if (cmd === "claude" && args.join(" ") === "mcp list") {
+          return {
+            code: 0,
+            stdout: "notion: npx -y easy-notion-mcp\n",
+            stderr: "",
+          };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      }),
+    });
+
+    await expect(runInit([], deps)).resolves.toBe(0);
+
+    expect(confirmCalls.some((call) => /already registered|existing|update|replace|skip/i.test(call.question))).toBe(true);
+    expect(addCalls(execCalls)).toHaveLength(0);
+  });
+
+  it("replaces a confirmed legacy notion registration before adding the new easy-notion-mcp server", async () => {
+    const runInit = await loadRunInit();
+    const { deps, execCalls } = await createDeps({
+      confirms: { existing: true },
+      exec: vi.fn(async (cmd: string, args: string[]) => {
+        if (cmd === "claude" && args.join(" ") === "mcp list") {
+          return {
+            code: 0,
+            stdout: "notion: npx -y easy-notion-mcp\n",
+            stderr: "",
+          };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      }),
+    });
+
+    await expect(runInit([], deps)).resolves.toBe(0);
+
+    expect(execCalls).toContainEqual({
+      cmd: "claude",
+      args: ["mcp", "remove", "notion", "-s", "user"],
+    });
+    expect(addCalls(execCalls)).toHaveLength(1);
+    expect(addCalls(execCalls)[0].args).toEqual([
+      "mcp",
+      "add",
+      "--scope",
+      "user",
+      "--transport",
+      "stdio",
+      "easy-notion-mcp",
+      "-e",
+      "NOTION_TOKEN=secret_notion_token",
+      "--",
+      "npx",
+      "-y",
+      "easy-notion-mcp",
+    ]);
+    expect(execCalls.findIndex((call) => call.args.join(" ") === "mcp remove notion -s user"))
+      .toBeLessThan(execCalls.findIndex((call) => call.args[0] === "mcp" && call.args[1] === "add"));
+  });
+
+  it("detects an easy-notion-mcp registration and does not clobber or duplicate it", async () => {
+    const runInit = await loadRunInit();
+    const { deps, confirmCalls, execCalls } = await createDeps({
+      exec: vi.fn(async (cmd: string, args: string[]) => {
+        if (cmd === "claude" && args.join(" ") === "mcp list") {
+          return {
+            code: 0,
+            stdout: "easy-notion-mcp: npx -y easy-notion-mcp\n",
+            stderr: "",
+          };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      }),
+    });
+
+    await expect(runInit([], deps)).resolves.toBe(0);
+
+    expect(confirmCalls.some((call) => /already registered|existing|update|replace|skip/i.test(call.question))).toBe(true);
+    expect(addCalls(execCalls)).toHaveLength(0);
+  });
+
+  it("registers a fresh Claude Code install with unpinned npx stdio config and token env", async () => {
+    const runInit = await loadRunInit();
+    const { deps, execCalls } = await createDeps();
+
+    await expect(runInit([], deps)).resolves.toBe(0);
+
+    expect(addCalls(execCalls)).toEqual([{
+      cmd: "claude",
+      args: [
+        "mcp",
+        "add",
+        "--scope",
+        "user",
+        "--transport",
+        "stdio",
+        "easy-notion-mcp",
+        "-e",
+        "NOTION_TOKEN=secret_notion_token",
+        "--",
+        "npx",
+        "-y",
+        "easy-notion-mcp",
+      ],
+    }]);
+    expect(addCalls(execCalls)[0].args.at(-1)).toBe("easy-notion-mcp");
+    expect(addCalls(execCalls)[0].args.join(" ")).not.toMatch(/easy-notion-mcp@/);
+  });
+
+  it("prints manual config blocks with the right top-level keys and never writes them to disk", async () => {
+    const runInit = await loadRunInit();
+    const writeFileSpy = vi.fn(async () => undefined);
+    const renameSpy = vi.fn(async () => undefined);
+    const { deps, io } = await createDeps({
+      which: vi.fn(async () => null),
+      fs: createFs({
+        exists: vi.fn(async () => false),
+        writeFile: writeFileSpy,
+        rename: renameSpy,
+      }),
+    });
+
+    await expect(runInit([], deps)).resolves.toBe(0);
+
+    expect(clientSection(io.output, "Cursor")).toContain('"mcpServers"');
+    expect(clientSection(io.output, "Windsurf")).toContain('"mcpServers"');
+    expect(clientSection(io.output, "Claude Desktop")).toContain('"mcpServers"');
+    expect(clientSection(io.output, "VS Code")).toContain('"servers"');
+    expect(clientSection(io.output, "VS Code")).not.toContain('"mcpServers"');
+    expect(writeFileSpy).not.toHaveBeenCalled();
+    expect(renameSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns on no shared pages, confirms sharing from a pasted Notion URL, and reports inaccessible pages", async () => {
+    const runInit = await loadRunInit();
+    const url = "https://www.notion.so/Shared-Page-1a2b3c4d5e6f7081920a1b2c3d4e5f60";
+    const pageId = notionUrlToPageId(url);
+    const confirmed = await createDeps({
+      answers: { url },
+      notion: {
+        search: vi.fn(async () => []),
+      },
+    });
+
+    await expect(runInit([], confirmed.deps)).resolves.toBe(0);
+
+    expect(confirmed.io.output).toMatch(/warning/i);
+    expect(confirmed.io.output).toMatch(/share.*pages/i);
+    expect(confirmed.notion.getPage).toHaveBeenCalledWith(pageId);
+    expect(confirmed.io.output).toMatch(/sharing confirmed/i);
+
+    const rejected = await createDeps({
+      answers: { url },
+      notion: {
+        search: vi.fn(async () => []),
+        getPage: vi.fn(async () => {
+          throw new Error("object_not_found");
+        }),
+      },
+    });
+
+    await expect(runInit([], rejected.deps)).resolves.toBe(0);
+    expect(rejected.io.output).toMatch(/share.*integration/i);
+  });
+
+  it("requests masked token entry in TTY mode and falls back gracefully without a TTY", async () => {
+    const runInit = await loadRunInit();
+    const tty = await createDeps({ isTTY: true });
+
+    await expect(runInit([], tty.deps)).resolves.toBe(0);
+
+    const tokenPrompt = tty.promptCalls.find((call) => /token/i.test(call.question));
+    expect(tokenPrompt?.opts).toMatchObject({ mask: true });
+
+    const nonTty = await createDeps({ isTTY: false });
+    await expect(runInit([], nonTty.deps)).resolves.toBe(0);
+    expect(nonTty.io.output).not.toMatch(/crash|fatal/i);
+  });
+
+  it("validates an optional root page id and warns without aborting when it is inaccessible", async () => {
+    const runInit = await loadRunInit();
+    const rootPageId = "1a2b3c4d5e6f7081920a1b2c3d4e5f60";
+    const { deps, io, notion } = await createDeps({
+      answers: { root: rootPageId },
+      notion: {
+        getPage: vi.fn(async (id: string) => {
+          if (id === rootPageId) {
+            throw new Error("object_not_found");
+          }
+          return { id, object: "page" };
+        }),
+      },
+    });
+
+    await expect(runInit(["--root-page-id", rootPageId], deps)).resolves.toBe(0);
+
+    expect(notion.getPage).toHaveBeenCalledWith(rootPageId);
+    expect(io.output).toMatch(/warning/i);
+    expect(io.output).toMatch(/root page/i);
+  });
+
+  it("installs bundled skills only on opt-in, atomically, and asks before replacing existing copies", async () => {
+    const runInit = await loadRunInit();
+    const skipped = await createDeps({
+      confirms: { skill: false },
+    });
+
+    await expect(runInit([], skipped.deps)).resolves.toBe(0);
+
+    expect(await skipped.deps.fs.exists(join(skipped.deps.skillsTargetDir, "notion-recipes"))).toBe(false);
+    expect(await skipped.deps.fs.exists(join(skipped.deps.skillsTargetDir, "easy-notion-cli"))).toBe(false);
+
+    const installed = await createDeps({
+      confirms: { skill: true },
+    });
+    await expect(runInit([], installed.deps)).resolves.toBe(0);
+
+    expect(await readFile(join(installed.deps.skillsTargetDir, "notion-recipes", "SKILL.md"), "utf8"))
+      .toContain("Notion recipes");
+    expect(await readFile(join(installed.deps.skillsTargetDir, "easy-notion-cli", "SKILL.md"), "utf8"))
+      .toContain("Easy Notion CLI");
+
+    const renameCalls = vi.mocked(installed.deps.fs.rename).mock.calls;
+    expect(renameCalls.length).toBeGreaterThanOrEqual(2);
+    for (const [oldPath, newPath] of renameCalls) {
+      expect(dirname(oldPath)).toBe(dirname(newPath));
+      expect(basename(oldPath)).toMatch(/tmp|temp/i);
+    }
+
+    await writeFile(join(installed.deps.skillsTargetDir, "notion-recipes", "SKILL.md"), "user copy\n");
+    const rerun = await createDeps({
+      skillsSourceDir: installed.deps.skillsSourceDir,
+      skillsTargetDir: installed.deps.skillsTargetDir,
+      confirms: { skill: true, overwrite: false },
+    });
+    await expect(runInit([], rerun.deps)).resolves.toBe(0);
+
+    expect(rerun.confirmCalls.some((call) => /overwrite|replace|already exists/i.test(call.question))).toBe(true);
+    expect(await readFile(join(installed.deps.skillsTargetDir, "notion-recipes", "SKILL.md"), "utf8")).toBe("user copy\n");
+  });
+});

--- a/tests/init-wizard.test.ts
+++ b/tests/init-wizard.test.ts
@@ -410,6 +410,9 @@ describe("init wizard", () => {
 
     await expect(runInit([], deps)).resolves.toBe(0);
 
+    expect(io.output).toContain("<paste-your-notion-token-here>");
+    expect(io.output).toMatch(/replace .*with your actual notion token/i);
+    expect(io.output).not.toContain("secret_notion_token");
     expect(clientSection(io.output, "Cursor")).toContain('"mcpServers"');
     expect(clientSection(io.output, "Windsurf")).toContain('"mcpServers"');
     expect(clientSection(io.output, "Claude Desktop")).toContain('"mcpServers"');

--- a/tests/stdio-startup.test.ts
+++ b/tests/stdio-startup.test.ts
@@ -2,6 +2,13 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
 import { describe, expect, it } from "vitest";
 
+type JsonRpcResponse = {
+  jsonrpc: "2.0";
+  id: number;
+  result?: any;
+  error?: any;
+};
+
 function waitForStartupMessage(child: ChildProcessWithoutNullStreams): Promise<string> {
   return new Promise((resolve, reject) => {
     let stderr = "";
@@ -40,6 +47,104 @@ function waitForStartupMessage(child: ChildProcessWithoutNullStreams): Promise<s
   });
 }
 
+function waitForJsonRpcResponse(
+  child: ChildProcessWithoutNullStreams,
+  id: number,
+): Promise<JsonRpcResponse> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for JSON-RPC response ${id}. stdout:\n${stdout}`));
+    }, 12_000);
+
+    const onData = (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+      const lines = stdout.split(/\r?\n/);
+      stdout = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+
+        let message: JsonRpcResponse;
+        try {
+          message = JSON.parse(line);
+        } catch (error) {
+          cleanup();
+          reject(new Error(`Malformed JSON-RPC line from server: ${line}`));
+          return;
+        }
+
+        if (message.id === id) {
+          cleanup();
+          resolve(message);
+          return;
+        }
+      }
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `Process exited before JSON-RPC response ${id} (code=${code}, signal=${signal}). stdout:\n${stdout}`,
+        ),
+      );
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.off("data", onData);
+      child.off("exit", onExit);
+    };
+
+    child.stdout.on("data", onData);
+    child.on("exit", onExit);
+  });
+}
+
+function waitForExitOutput(child: ChildProcessWithoutNullStreams): Promise<{
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+
+    const timeout = setTimeout(() => {
+      cleanup();
+      child.kill("SIGTERM");
+      reject(new Error(`Timed out waiting for process exit. stdout:\n${stdout}\nstderr:\n${stderr}`));
+    }, 12_000);
+
+    const onStdout = (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    };
+    const onStderr = (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal, stdout, stderr });
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.off("data", onStdout);
+      child.stderr.off("data", onStderr);
+      child.off("exit", onExit);
+    };
+
+    child.stdout.on("data", onStdout);
+    child.stderr.on("data", onStderr);
+    child.on("exit", onExit);
+  });
+}
+
 async function stopChildProcess(child: ChildProcessWithoutNullStreams) {
   if (child.exitCode !== null || child.signalCode !== null) {
     return;
@@ -68,5 +173,73 @@ describe("stdio startup", () => {
     } finally {
       await stopChildProcess(child);
     }
+  }, 15_000);
+
+  it("starts the stdio MCP server with no args and completes initialize", async () => {
+    const child = spawn(process.execPath, ["dist/index.js"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NOTION_TOKEN: "ntn_fake",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdoutBeforeInitialize = "";
+    const collectStdout = (chunk: Buffer | string) => {
+      stdoutBeforeInitialize += chunk.toString();
+    };
+    child.stdout.on("data", collectStdout);
+
+    try {
+      const stderr = await waitForStartupMessage(child);
+      child.stdout.off("data", collectStdout);
+
+      expect(stderr).toContain("easy-notion-mcp running on stdio");
+      expect(stdoutBeforeInitialize).toBe("");
+
+      const initializeResponse = waitForJsonRpcResponse(child, 1);
+      child.stdin.write(`${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "stdio-startup-test", version: "0.0.1" },
+        },
+      })}\n`);
+
+      await expect(initializeResponse).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          serverInfo: {
+            name: "easy-notion-mcp",
+          },
+        },
+      });
+    } finally {
+      child.stdout.off("data", collectStdout);
+      await stopChildProcess(child);
+    }
+  }, 15_000);
+
+  it("routes init before the NOTION_TOKEN startup check", async () => {
+    const child = spawn(process.execPath, ["dist/index.js", "init"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NOTION_TOKEN: "",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.end();
+
+    const { stdout, stderr } = await waitForExitOutput(child);
+    const output = `${stdout}\n${stderr}`;
+
+    expect(output).not.toContain("NOTION_TOKEN is required");
+    expect(output).toMatch(/easy-notion.*(init|setup|wizard)|Notion.*(init|setup|wizard)/i);
   }, 15_000);
 });


### PR DESCRIPTION
## What

Phase 1 of the one-command bootstrap: `npx easy-notion-mcp init` (also `easy-notion init`), an interactive setup wizard scoped to **Claude Code only**. Lowers onboarding from manual MCP-config editing to a guided flow.

Wizard flow: detect Claude Code → masked token entry → **live `get_me` validation** → optional live-validated root page → **idempotent registration** via `claude mcp add` (detects an existing server, including a legacy `notion`, and offers replace/skip rather than duplicating) → no-shared-pages guard → copy-paste config blocks for other clients → opt-in atomic cookbook-skill install → restart guidance.

For clients other than Claude Code, the wizard prints a manual config block only; it does not write to any client's JSON config. That guarded JSON-merge path is deliberately Phase 2.

## Scope / contract

- **Additive, CLI-only.** The frozen 1.0 **MCP tool contract is untouched** (`src/server.ts` unchanged) — no new/changed tools, args, or schemas.
- The `init` branch is a **lazy dynamic import placed before the stdio entrypoint's token check**, so no-arg `node dist/index.js` startup is unaffected. Pinned by a test.

## Commits

1. `docs(plan)` — the reviewed, Codex-pressure-tested plan doc (carried onto the branch for durability).
2. `feat(cli)` — the Phase 1 wizard + tests.
3. `fix(cli)` — manual config blocks print a **token placeholder + substitution instruction**, never the real token (keeps the live secret out of terminal scrollback / captured stdout).
4. `fix(cli)` — **`openBrowser` is guarded behind `isTTY`**: the token page only auto-opens in an interactive terminal, so non-interactive/CI/scripted runs no longer pop a browser. The URL is still printed in all cases.

## For review

- **Startup timeout bumps** — `tests/http-bin-startup.test.ts` (12s→30s) and the new `tests/stdio-startup.test.ts` are process-spawn tests that flake under heavy parallel suite load (they pass in isolation). The change adds spawn-based tests, which raised full-suite load past the old window. Not a server regression; CI should confirm green.
- **Token handling** — confirm the manual blocks show only the placeholder (`<paste-your-notion-token-here>`), and that the real token is used solely by the `claude mcp add` registration path (not printed for manual copy).
- **No-shared-pages guard + idempotent re-run** — worth a look for the edge where a legacy `notion` server already exists.

## Deferred to Phase 2/3 (as planned)

Guarded JSON deep-merge writer + `code --add-mcp` for other clients, JSONC refuse-and-instruct, OS path-matrix auto-detection, profiles / OAuth / `--yes` non-interactive mode.
